### PR TITLE
(QENG-1703) Update clamps to support PE 3.7

### DIFF
--- a/lib/facter/lots_of_facts.rb
+++ b/lib/facter/lots_of_facts.rb
@@ -1,14 +1,21 @@
-# generate a random hash with a lot of crap in it, turn it into facts
+# To compensate for our "fake" agents having virtually no facts,
+# generate some random facts. To better stress test puppetdb, (avoid its data
+# deduplication) these facts should:
+#
+# contain different data each run
+# have the same fact name so we don't end up with 4 million facts in puppetdb
+# have verying length, to simulate things like SSH keys.
 
 require 'securerandom'
 require 'facter'
 
-$num_of_facts = rand(5..75)
-
+num_facts = File.exist?('/etc/puppetlabs/num_facts') ? File.read('/etc/puppetlabs/num_facts') : 500
 hash_of_facts = Hash.new {|h,k| h[k] = [] }
 
-for i in 1..$num_of_facts
-  hash_of_facts[SecureRandom.hex] << SecureRandom.hex
+for i in 1..num_facts
+  fact_value = ""
+  rand(1..50).times { fact_value << SecureRandom.hex }
+  hash_of_facts["fact_#{i}"] << fact_value
 end
 
 hash_of_facts.each_pair do |factname, factvalue|

--- a/lib/facter/lots_of_facts.rb
+++ b/lib/facter/lots_of_facts.rb
@@ -9,7 +9,7 @@
 require 'securerandom'
 require 'facter'
 
-num_facts = File.exist?('/etc/puppetlabs/num_facts') ? File.read('/etc/puppetlabs/num_facts') : 500
+num_facts = File.exist?('/etc/puppetlabs/clamps/num_facts') ? File.read('/etc/puppetlabs/clamps/num_facts') : 500
 hash_of_facts = Hash.new {|h,k| h[k] = [] }
 
 for i in 1..num_facts

--- a/lib/facter/lots_of_facts.rb
+++ b/lib/facter/lots_of_facts.rb
@@ -9,7 +9,7 @@
 require 'securerandom'
 require 'facter'
 
-num_facts = File.exist?('/etc/puppetlabs/clamps/num_facts') ? File.read('/etc/puppetlabs/clamps/num_facts') : 500
+num_facts = File.exist?('/etc/puppetlabs/clamps/num_facts') ? File.read('/etc/puppetlabs/clamps/num_facts').to_i : 500
 hash_of_facts = Hash.new {|h,k| h[k] = [] }
 
 for i in 1..num_facts

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -6,8 +6,15 @@ class clamps::agent (
   $metrics_port        = 2003,
   $metrics_server      = undef,
   $nonroot_users       = '2',
+  $num_facts_per_agent = 500,
   $shuffle_amq_servers = true,
 ) {
+
+
+  file { '/etc/puppetlabs/clamps/num_facts':
+    ensure  => file,
+    content => $num_facts_per_agent,
+  }
 
   $nonroot_usernames = clamps_users($nonroot_users)
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,30 +1,35 @@
 class clamps::agent (
-  $nonroot_users = '2',
-  $master = $::servername,
-  $amqserver = $::servername,
-  $ca     = $::settings::ca_server,
-  $amqpass = file('/etc/puppetlabs/mcollective/credentials'),
-  $metrics_server = undef,
-  $metrics_port = 2003,
+  $amqpass             = file('/etc/puppetlabs/mcollective/credentials'),
+  $amqserver           = [$::servername],
+  $ca                  = $::settings::ca_server,
+  $master              = $::servername,
+  $metrics_port        = 2003,
+  $metrics_server      = undef,
+  $nonroot_users       = '2',
+  $shuffle_amq_servers = true,
 ) {
 
   $nonroot_usernames = clamps_users($nonroot_users)
 
-  ::clamps::users { $nonroot_usernames: 
+  ::clamps::users { $nonroot_usernames:
     servername     => $master,
     ca_server      => $ca,
     metrics_server => $metrics_server,
     metrics_port   => $metrics_port,
   }
 
+  $amq_servers = $shuffle_amq_servers ? {
+    true    => shuffle($amqserver),
+    default => $amqserver,
+  }
 
   # This will not allow the "main" mcollective to start as
   # it simply checks for a process named mcollective.
   # The status override in the service resource makes the
   # non-root nodes work though
-  ::clamps::mcollective { $nonroot_usernames: 
-    amqserver => $amqserver,
-    amqpass   => $amqpass,
+  ::clamps::mcollective { $nonroot_usernames:
+    amqservers => $amq_servers,
+    amqpass    => $amqpass,
   }
 
   # Need to manage the ec2-user if you enabled this

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -10,6 +10,9 @@ class clamps::agent (
   $shuffle_amq_servers = true,
 ) {
 
+  file { '/etc/puppetlabs/clamps':
+    ensure => directory
+  }
 
   file { '/etc/puppetlabs/clamps/num_facts':
     ensure  => file,

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -4,13 +4,17 @@ class clamps::agent (
   $amqserver = $::servername,
   $ca     = $::settings::ca_server,
   $amqpass = file('/etc/puppetlabs/mcollective/credentials'),
+  $metrics_server = undef,
+  $metrics_port = 2003,
 ) {
 
   $nonroot_usernames = clamps_users($nonroot_users)
 
   ::clamps::users { $nonroot_usernames: 
-    servername => $master,
-    ca_server  => $ca,
+    servername     => $master,
+    ca_server      => $ca,
+    metrics_server => $metrics_server,
+    metrics_port   => $metrics_port,
   }
 
 

--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -1,7 +1,7 @@
 define clamps::mcollective (
   $user       = $title,
   $amqpass    = 'password',
-  $amqservers = [$::servername],
+  $amqservers = [$::settings::server],
 ) {
 
   # Directories to create / files to copy

--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -1,7 +1,7 @@
 define clamps::mcollective (
-  $user = $title,
-  $amqpass = 'password',
-  $amqserver = '$::server',
+  $user       = $title,
+  $amqpass    = 'password',
+  $amqservers = [$::servername],
 ) {
 
   # Directories to create / files to copy
@@ -39,7 +39,7 @@ define clamps::mcollective (
   file { "/home/$user/.mcollective/ssl/amq.cert.pem":
     content  => file("/etc/puppetlabs/puppet/ssl/certs/${settings::certname}.pem"),
   }
-  
+
   file { "/home/$user/.mcollective/ssl/clients/peadmin-public.pem":
     content  => file('/etc/puppetlabs/puppet/ssl/public_keys/pe-internal-peadmin-mcollective-client.pem'),
   }
@@ -60,5 +60,4 @@ define clamps::mcollective (
     stop      => "kill -9 `pgrep -u $user mcollectived`",
     subscribe => File["/home/$user/.mcollective/server.cfg"],
   }
-
 }

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -39,7 +39,7 @@ define clamps::users (
   }
 
   cron { "cron.puppet.${user}":
-    command => '/opt/puppet/bin/puppet agent --onetime --no-daemonize',
+    command => 'TIMEFORMAT="metrics.agent.time %R `date +%s`"; TIME=$( { time /opt/puppet/bin/puppet agent --onetime --no-daemonize > /dev/null; } 2>&1 ); echo "${TIME}" | nc metrics 2003',
     user    => $user,
     minute  => [ $cron_1, $cron_2 ],
     require => File["/home/${user}/.puppet"],

--- a/templates/clamps_server.cfg.erb
+++ b/templates/clamps_server.cfg.erb
@@ -1,4 +1,3 @@
-
 # Centrally managed by Puppet version 3.7.1 (Puppet Enterprise 3.4.0-rc1-1223-g488a64a)
 # https://docs.puppetlabs.com/mcollective/configure/server.html
 
@@ -8,15 +7,17 @@ connector = activemq
 direct_addressing = 1
 
 # ActiveMQ connector settings:
-plugin.activemq.pool.size = 1
-plugin.activemq.pool.1.host = <%= @amqserver %>
-plugin.activemq.pool.1.port = 61613
-plugin.activemq.pool.1.user = mcollective
-plugin.activemq.pool.1.password = <%= @amqpass %> 
-plugin.activemq.pool.1.ssl = true
-plugin.activemq.pool.1.ssl.ca = /home/<%= @user %>/.mcollective/ssl/ca.cert.pem
-plugin.activemq.pool.1.ssl.cert = /home/<%= @user %>/.mcollective/ssl/amq.cert.pem
-plugin.activemq.pool.1.ssl.key = /home/<%= @user %>/.mcollective/ssl/amq.private_key.pem
+plugin.activemq.pool.size = <%= @amqservers.count %>
+<% @amqservers.each_with_index do |server,index| -%>
+plugin.activemq.pool.<%= index + 1 %>.host = <%= server %>
+plugin.activemq.pool.<%= index + 1 %>.port = 61613
+plugin.activemq.pool.<%= index + 1 %>.user = mcollective
+plugin.activemq.pool.<%= index + 1 %>.password = <%= @stomp_password %>
+plugin.activemq.pool.<%= index + 1 %>.ssl = true
+plugin.activemq.pool.<%= index + 1 %>.ssl.ca = /home/<%= @user %>/.mcollective/ssl/ca.cert.pem
+plugin.activemq.pool.<%= index + 1 %>.ssl.cert = /home/<%= @user %>/.mcollective/ssl/amq.cert.pem
+plugin.activemq.pool.<%= index + 1 %>.ssl.key = /home/<%= @user %>/.mcollective/ssl/amq.private_key.pem
+<% end -%>
 
 # Security plugin settings (required):
 # -----------------------------------


### PR DESCRIPTION
Previous to these serious of commits, clamps assumed a single AMQ server. These commits adds support for hub and spoke AMQ, limit the number of facts generated and if configued, log agent run times to a graphite server.