### PR TITLE
(QENG-1788) Don't use the systemd service provider

### DIFF
--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -54,6 +54,7 @@ define clamps::mcollective (
   }
 
   service { "pe-mcollective-$user":
+    provider  => base,
     ensure    => running,
     start     => "su $user -c \'/opt/puppet/sbin/mcollectived --pid /home/$user/.mcollective/pe-mcollective.pid --config=/home/$user/.mcollective/server.cfg &\'",
     status    => "pgrep -u $user mcollectived",


### PR DESCRIPTION
The default service provider for el7 (rhel and centos) uses:
https://github.com/puppetlabs/puppet/blob/master/lib/puppet/provider/service/systemd.rb

Which always checks for the status of a service with:
systemctl("is-active", @resource[:name])
ignoring the "status" attribute defined in the service at
https://github.com/puppetlabs/clamps/blob/master/manifests/mcollective.pp

By changing the provider to "base", we skip using systemd completely.