### PR TITLE
Add hiera data bindings support

### DIFF
--- a/lib/puppet/parser/functions/clamps_hiera_defaults.rb
+++ b/lib/puppet/parser/functions/clamps_hiera_defaults.rb
@@ -1,0 +1,50 @@
+#!/opt/puppet/bin/ruby
+require 'puppet/face'
+require 'yaml'
+
+module Puppet::Parser::Functions
+  newfunction(:clamps_hiera_defaults, :type => :rvalue, :arity => 0, :doc => <<-EOS
+  This function reads through the modules on disk via the resource_type face
+  It then determines the parameters for these classes and their defaults.
+  It creates hiera data binding compatible key names i.e. 'apache::user'
+  and the evaluated ruby object as the value. This preserves boolean/hash/array 
+  EOS
+) do |args|
+   
+  #Puppet.parse_config
+  environment = Puppet[:environment] || 'production'
+  resources = Puppet::Face[:resource_type, '0.0.1'].search('.*',{:extra => { 'environment' => environment }}) 
+   
+  response = Hash.new
+    resources.each do |resource|
+     resource.arguments.each do |k,v|
+        # Walk the AST types and evaluate them, Puppet 4 may need updates
+        case v.class.to_s
+          when "Puppet::Parser::AST::String"
+            result = v.evaluate('subscope')
+          when "Puppet::Parser::AST::Undef"
+            # "We don't want undef values..."
+            next 
+          #when "Puppet::Parser::AST::Variable"
+          #  # Remove the $ in the name and wrap in hiera
+          #  # inpolation to defer the lookup until runtime
+          #  result = "%{#{v.to_s[1..-1]}}"
+          when "Puppet::Parser::AST::ASTHash"
+            result = v.evaluate('subscope')
+            break if result.empty?
+          when "Puppet::Parser::AST::ASTArray"
+            result = v.evaluate('subscope')
+          when "Puppet::Parser::AST::Boolean"
+            result = v.evaluate('subscope')
+          else
+            # "We don't want raw puppet code like functions..."
+            next
+          end
+        # This should generate keys like "class::param": "value"
+        # eyaml auto quotes anything with a colon in the string
+        response["#{resource.name}::#{k.to_s}"] = result
+      end 
+    end
+    response
+  end
+end

--- a/manifests/master/hiera.pp
+++ b/manifests/master/hiera.pp
@@ -1,0 +1,41 @@
+class clamps::master::hiera (
+  $generate_data_bindings = true,
+) {
+  $defaults = clamps_hiera_defaults()
+
+  File {
+    owner    => $::settings::user,
+    group    => $::settings::group, 
+  }
+
+  # This is using http://forge.puppetlabs.com/hunner/hiera
+  class { '::hiera':
+    backends     => [
+      'yaml',
+    ],
+    datadir      => "${::settings::confdir}/hieradata", 
+    hierarchy    => [
+      'servers/%{::clientcert}',
+      '%{environment}',
+      'global',
+    ],
+    datadir_manage => false,
+  }
+
+  # Normally this directory would live in the control repo
+  # We pragmatically generate this data so it should not be
+  # Version controlled.
+
+  file { "${::settings::confdir}/hieradata":
+    ensure  => directory,
+  }
+
+
+  # The function above generates hiera data keys from the
+  # existing classes and their params on disk
+
+  file { "${::settings::confdir}/hieradata/global.yaml":
+    ensure  => file,
+    content => inline_template("<%= @defaults.to_yaml %>"),
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,61 @@
+{
+  "author": "Puppetlabs",
+  "license": "Apache License, Version 2.0",
+  "name": "puppetlabs-clamps",
+  "operatingsystem_support": [],
+  "project_page": "https://github.com/puppetlabs/clamps",
+  "issues_url": "https://github.com/puppetlabs/clamps/issues",
+  "source": "https://github.com/puppetlabs/clamps",
+  "summary": "Scale testing puppet master environments",
+  "tags": [ "pe", "environment", "mcollective"],
+  "version": "1.0.0",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "hunner/hiera",
+      "version_requirement": ">= 1.2.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": "3.x"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ]
+}


### PR DESCRIPTION
Prior to this commit we did not test hiera
during clamps testing. This PR adds a new
function and respective class that will
configure hiera and generate an intial
yaml file that contains key value pairs
for all classes in the module path and
all default values that they have assigned