### PR TITLE
(QENG-2261) Add and use `$splay` and `$splaylimit` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@ Assign `clamps::agent` to the root agents on your nodes, as it will install the 
 
 This class accepts the following parameters:
 
- - `$amqpass`: credentials for MCollective AMQP bus
- - `$amqserver`: server name for MCollective AMQP connection
- - `$ca`: name of CA server
- - `$daemonize`: run non-root agents daemonized? (default: `false`)
- - `$master`: name of puppet master server
- - `$metrics_port`: port to connect to graphite server
- - `$metrics_server`: name of server where graphite is running
- - `$nonroot_users`: number of non-root user agents to create (default: 2)
- - `$num_facts_per_agent`: number of facts to create per non-root user agent
- - `$shuffle_amq_servers`: randomize AMQP servers? (default: `true`)
- - `$splay`: enable `--splay` setting on cron-based non-root user agent runs?
- - `$splaylimit`: specify `--splaylimit` setting for cron-based non-root users agent runs.  Implies `$splay`.
+ - `$amqpass` (`String`): Credentials for MCollective AMQP bus.
+ - `$amqserver` (`String`): Server name for MCollective AMQP connection.
+ - `$ca` (`String`): Name of CA server.
+ - `$daemonize` (`Boolean`): Run non-root agents daemonized? (default: `false`)
+ - `$master` (`String`): Name of puppet master server.
+ - `$metrics_port` (`Integer`): Port to use when connecting to graphite server.
+ - `$metrics_server` (`String`): Name of server where graphite is running.
+ - `$nonroot_users` (`Integer`): Number of non-root user agents to create. (default: 2)
+ - `$num_facts_per_agent` (`Integer`): Number of facts to create per non-root user agent.
+ - `$shuffle_amq_servers` (`Boolean`): Randomize AMQP servers? (default: `true`)
+ - `$splay` (`Boolean`):  Enable `--splay` for non-user agent runs? (default: `false`).  See [Configuration: splay](https://docs.puppetlabs.com/references/latest/configuration.html#splay) for puppet agent semantics.
+ - `$splaylimit` (`String`): Set the `--splaylimit` parameter for non-user agent runs? (default: unset). Implies `splay`.  See [Configuration: splaylimit](https://docs.puppetlabs.com/references/latest/configuration.html#splaylimit) for puppet agent semantics.
 
 #### `clamps`
 
@@ -36,7 +36,7 @@ Assign `clamps` to the non-root agents on your nodes.
 
 This class accepts the following parameter:
 
- - `$logic`: relative level of complexity (hence load) to be introduced to the system. Higher values mean more complexity.
+ - `$logic` (`Integer`): relative level of complexity (hence load) to be introduced to the system. Higher values mean more complexity.
 
 ## Clamps Classification
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This class accepts the following parameters:
  - `$nonroot_users`: number of non-root user agents to create (default: 2)
  - `$num_facts_per_agent`: number of facts to create per non-root user agent
  - `$shuffle_amq_servers`: randomize AMQP servers? (default: `true`)
+ - `$splay`: enable `--splay` setting on cron-based non-root user agent runs?
+ - `$splaylimit`: specify `--splaylimit` setting for cron-based non-root users agent runs.  Implies `$splay`.
 
 #### `clamps`
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -9,6 +9,8 @@ class clamps::agent (
   $nonroot_users       = '2',
   $num_facts_per_agent = 500,
   $shuffle_amq_servers = true,
+  $splay               = false,
+  $splaylimit          = undef,
 ) {
 
   file { '/etc/puppetlabs/clamps':
@@ -28,6 +30,8 @@ class clamps::agent (
     metrics_server => $metrics_server,
     metrics_port   => $metrics_port,
     daemonize      => $daemonize,
+    splay          => $splay,
+    splaylimit     => $splaylimit,
   }
 
   $amq_servers = $shuffle_amq_servers ? {

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -55,13 +55,12 @@ define clamps::users (
   } else {
 
     if $splaylimit {
-      $splay = true
       $splaylimitarg = "--splaylimit ${splaylimit}"
     } else {
       $splaylimitarg = ""
     }
 
-    if $splay {
+    if $splay or $splaylimit {
       $splayarg = "--splay"
     } else {
       $splayarg = ""

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -5,6 +5,8 @@ define clamps::users (
   $metrics_server = undef,
   $metrics_port   = 2003,
   $daemonize      = false,
+  $splay          = false,
+  $splaylimit     = undef,
 ) {
 
   $cron_1 = fqdn_rand('30',$user)
@@ -52,15 +54,28 @@ define clamps::users (
 
   } else {
 
+    if $splaylimit {
+      $splay = true
+      $splaylimitarg = "--splaylimit ${splaylimit}"
+    } else {
+      $splaylimitarg = ""
+    }
+
+    if $splay {
+      $splayarg = "--splay"
+    } else {
+      $splayarg = ""
+    }
+
     if $metrics_server {
       file { "/home/${user}/time-puppet-run.sh":
         ensure => file,
-        content => "TIMEFORMAT=\"metrics.${::fqdn}.${user}.time %R `date +%s`\"; TIME=$( { time /opt/puppet/bin/puppet agent --onetime --no-daemonize > /dev/null; } 2>&1 ); echo \$TIME | nc ${metrics_server} ${metrics_port}",
+        content => "TIMEFORMAT=\"metrics.${::fqdn}.${user}.time %R `date +%s`\"; TIME=$( { time /opt/puppet/bin/puppet agent --onetime --no-daemonize ${splayarg} ${splaylimitarg} > /dev/null; } 2>&1 ); echo \$TIME | nc ${metrics_server} ${metrics_port}",
       }
     }
 
     $cron_command = $metrics_server ? {
-      undef   => '/opt/puppet/bin/puppet agent --onetime --no-daemonize',
+      undef   => "/opt/puppet/bin/puppet agent --onetime --no-daemonize ${splayarg} ${splaylimitarg}",
       default => "/home/${user}/time-puppet-run.sh",
     }
 


### PR DESCRIPTION
![](http://i.ytimg.com/vi/sRjphb4mojQ/maxresdefault.jpg)

For scale testing we wish to support enabling `splay` on non-daemonized agent runs. We will pass this in from the config file. Here we pass it down through the classes to ultimately set the `--splay` and `--splaylimit <limit>` args to the puppet agent.

A related pull on https://github.com/puppetlabs/pe_acceptance_tests will be necessary.

**todo**

 - [x] cut `pe_acceptance_tests` PR
 - [x] deploy nodes with both of these PRs
   - [x] in-progress: consistent problems with SSH auth failures after some setup on AWS nodes (wtf?)
 - [x] verify the new behavior works
 - [x] add documentation
 - [ ] :shipit: 

/cc @ericwilliamson @doug-rosser @acidprime 
/cf https://github.com/puppetlabs/clamps/pull/7/ https://github.com/puppetlabs/pe_acceptance_tests/pull/595/