### PR TITLE
[QENG-2463] Allow for better control of fact randomization 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,74 @@
-Clamps is a puppet module designed to help simulate realistic facts and resources during scale testing. We anticipate it being used with  [beaker](https://github.com/puppetlabs/beaker), as we do at Puppet Labs, where we set up clusters of nodes using Amazon EC2.
+CLAMPS is a puppet module designed to help simulate realistic facts and resources during scale testing. We anticipate it being used with  [beaker](https://github.com/puppetlabs/beaker), as we do at Puppet Labs, where we set up clusters of nodes using Amazon EC2.
 
-The technique is to generate a random set of users on a machine each running a non-root agent out of the user's home directory. It also generates facts for each run (up to the number specified in the configuration), of which some speficiable percentage will have changing values on each run, which will interact with  puppetdb's fact caching.
+In order to allow scaling up the number of agents connecting to puppet masters
+without the cost and overhead of scaling actual servers or VMs, we instead
+generate a set of users on a machine, and have each run a non-root puppet agent
+out of that user's home directory. This implies that we cannot manage all
+resources on the agent side, but we can at least go through full request and
+compile cycles with real agents.
 
-In our testing, an Amazon EC2 `m3.xlarge` node can run about 100 users with responsive mcollective and puppet runs.
+We also generate facts for each non-root agent (up to the number of facts
+specified in the configuration), of which some specifiable percentage will have
+changing values on each run. Additionally, we generate dynamically changing
+`File` resources.
 
-## Clamps classes
+In our testing, an Amazon EC2 `m3.xlarge` node can run about 100 non-root agents with responsive mcollective and puppet runs.
 
+### Fact generation
+
+To compensate for our non-root user agents having virtually no facts, and to
+exercise the parts of the stack which need to handle changing fact data (e.g.,
+puppetdb), we generate facts and provide changing fact values over the course
+of multiple runs here.
+
+We allow the CLAMPS configuration to dictate how many facts are generated, and
+what percentage of facts should change over each run. In earlier
+implementations, fact randomization generated long random values for every fact,
+with every value changing on every run. This meant 100% fact churn, which ends
+up trashing the puppetdb fact cache (which ends up doing bad things to
+puppetdb).
+
+Since the goal of CLAMPS is to provide load sufficient to exercise a puppet
+deployment, and to give confidence that if the running system falls over that
+it was not due to the artificial nature of testing, this prior approach was
+undesirable.
+
+Fact generation now behaves like this:
+
+ - We extracted a set of real-world fact names, along with the lengths of their
+   values, from an agent running on an EC2 node. This allows us to generate
+   facts and values with at least the length distributions we could expect to
+   see in the real world.
+
+ - We then generate a list of CLAMPS fact names for the non-root agent.
+   For a given number of facts per agent (`$num_facts_per_agent` in the
+   `clamps::agent` class), the same list of fact names will always be generated.
+   These will be in the form clamps_factname_index (e.g., `clamps_uptime_3`).
+   This also implies a consistency across agents running independently -- i.e.,
+   if two agents are requested to have 100 facts, they will be the same 100
+   named facts on each agent.
+
+ - Based upon configuration (`$percent_changed_facts` in the `clamps::agent`
+   class), we choose a certain number of facts to receive random values each
+   run. The names of the facts which get random values will be consistent
+   between runs, while all other facts always have the same values. This will
+   also be consistent between agents as well, provided the
+   `$num_facts_per_agent` and `$percent_changed_facts` values are set
+   identically.
+
+ - By choosing a fixed set of fact names to change we avoid variation in
+   churn. The alternative is that if a random, say, 10% of facts are given
+   random values, we are either forced to save old fact values between runs to
+   avoid changing them (which introduces unwanted storage and serialization
+   headaches), or we end up changing old "randomized" values back to some known
+   fixed value while we randomize other fact values (which results in an
+   inconsistent amount of change between runs).
+
+Our techniques here should also better simulate real-world behavior, where
+many facts never change over the lifetime of a node, and certain specific
+facts are known to change regularly, across most nodes.
+
+# CLAMPS classes
 
 #### `clamps:master`
 
@@ -39,17 +102,17 @@ This class accepts the following parameter:
 
  - `$logic` (`Integer`): relative level of complexity (hence load) to be introduced to the system. Higher values mean more complexity.
 
-## Clamps Classification
+## CLAMPS Classification
 
-We make use of clamps by assigning the nodes we're scale testing into clamps-related node groups via the Puppet Enterprise web console (see the "Classification" tab there).
+We make use of CLAMPS by assigning the nodes we're scale testing into CLAMPS-related node groups via the Puppet Enterprise web console (see the "Classification" tab there).
 
 The node groups of interest:
 
 #### `Clamps CA`
 
- - `Clamps CA`: which node will act as the CA for clamps agents? We typically pin a specific node to this group.
+ - `Clamps CA`: which node will act as the CA for CLAMPS agents? We typically pin a specific node to this group.
 
-![designating a clamps CA](https://cloud.githubusercontent.com/assets/6259/7121830/edfdc0c2-e1dc-11e4-9760-b9708dea0bf2.png)
+![designating a CLAMPS CA](https://cloud.githubusercontent.com/assets/6259/7121830/edfdc0c2-e1dc-11e4-9760-b9708dea0bf2.png)
 
 This node group also assigns the `clamps::master` class to its members.
 
@@ -57,9 +120,9 @@ This node group also assigns the `clamps::master` class to its members.
 
 #### `Clamps - Agent Nodes`
 
- - `Clamps - Agent Nodes`: which agents will have the clamps module installed? This includes both real nodes (or root agents) and non-root agents.
+ - `Clamps - Agent Nodes`: which agents will have the CLAMPS module installed? This includes both real nodes (or root agents) and non-root agents.
 
-![identifying clamps agent nodes](https://cloud.githubusercontent.com/assets/6259/7121873/2b7e6546-e1dd-11e4-8092-17745f1831c1.png)
+![identifying CLAMPS agent nodes](https://cloud.githubusercontent.com/assets/6259/7121873/2b7e6546-e1dd-11e4-8092-17745f1831c1.png)
 
 This node group also assigns the `clamps::agent` class to its members.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This class accepts the following parameters:
  - `$metrics_server` (`String`): Name of server where graphite is running.
  - `$nonroot_users` (`Integer`): Number of non-root user agents to create. (default: 2)
  - `$num_facts_per_agent` (`Integer`): Number of facts to create per non-root user agent.
- - `$percent_changed_facts` (Integer): What percentage (0-100) of facts will have new values on each run?
+ - `$percent_changed_facts` (`Integer`): What percentage (0-100) of facts will have new values on each run?
  - `$shuffle_amq_servers` (`Boolean`): Randomize AMQP servers? (default: `true`)
  - `$splay` (`Boolean`):  Enable `--splay` for non-user agent runs? (default: `false`).  See [Configuration: splay](https://docs.puppetlabs.com/references/latest/configuration.html#splay) for puppet agent semantics.
  - `$splaylimit` (`String`): Set the `--splaylimit` parameter for non-user agent runs? (default: unset). Implies `splay`.  See [Configuration: splaylimit](https://docs.puppetlabs.com/references/latest/configuration.html#splaylimit) for puppet agent semantics.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Clamps is a puppet module designed to help simulate realistic facts and resources during scale testing. We anticipate it being used with  [beaker](https://github.com/puppetlabs/beaker), as we do at Puppet Labs, where we set up clusters of nodes using Amazon EC2.
 
-The technique is to generate a random set of users on a machine each running a non-root agent out of the user's home directory. It also generates a random number of facts (from 5 to 75 facts). Since these facts change on each puppet run, this additionally creates puppetdb activity.
+The technique is to generate a random set of users on a machine each running a non-root agent out of the user's home directory. It also generates facts for each run (up to the number specified in the configuration), of which some speficiable percentage will have changing values on each run, which will interact with  puppetdb's fact caching.
 
 In our testing, an Amazon EC2 `m3.xlarge` node can run about 100 users with responsive mcollective and puppet runs.
 
@@ -26,6 +26,7 @@ This class accepts the following parameters:
  - `$metrics_server` (`String`): Name of server where graphite is running.
  - `$nonroot_users` (`Integer`): Number of non-root user agents to create. (default: 2)
  - `$num_facts_per_agent` (`Integer`): Number of facts to create per non-root user agent.
+ - `$percent_changed_facts` (Integer): What percentage (0-100) of facts will have new values on each run?
  - `$shuffle_amq_servers` (`Boolean`): Randomize AMQP servers? (default: `true`)
  - `$splay` (`Boolean`):  Enable `--splay` for non-user agent runs? (default: `false`).  See [Configuration: splay](https://docs.puppetlabs.com/references/latest/configuration.html#splay) for puppet agent semantics.
  - `$splaylimit` (`String`): Set the `--splaylimit` parameter for non-user agent runs? (default: unset). Implies `splay`.  See [Configuration: splaylimit](https://docs.puppetlabs.com/references/latest/configuration.html#splaylimit) for puppet agent semantics.

--- a/lib/facter/lots_of_facts.rb
+++ b/lib/facter/lots_of_facts.rb
@@ -3,7 +3,7 @@
 # puppetdb), we generate facts and provide changing fact values over the course
 # of multiple runs here.
 #
-# We allow the clamps configuration to dictate how many facts are generated, and
+# We allow the CLAMPS configuration to dictate how many facts are generated, and
 # what percentage of facts should change over each run.
 #
 # In earlier implementations, fact randomization generated long random values
@@ -23,7 +23,7 @@
 # facts and values with at least the length distributions we could expect to see
 # in the real world.
 #
-# We generate a list of clamps fact names that will be persistent across runs.
+# We generate a list of CLAMPS fact names that will be persistent across runs.
 # For a given number of facts per agent (`#number_of_facts`, below), the same
 # list of fact names will always be generated. These will be in the form
 # clamps_factname_index (e.g., "clamps_uptime_3"). This also implies a
@@ -124,11 +124,11 @@ def permute(list)
   working
 end
 
-# Returns a randomized sublist of length `length` from the list `list`.
+# Returns a stable randomized sublist of length `length` from the list `list`.
 #
 # We use the Fisher-Yates `#permute` method to generate a shuffled `list`,
 # and select `length` elements from the front. We guarantee to provide the same
-#  sublist for a given `list` + `length` combo, whenever it is called (even
+# sublist for a given `list` + `length` combo, whenever it is called (even
 # across different process invocations), hence "stable".
 def stable_random_sublist(list, length)
   srand(1234567890)   # seed is arbitrary, but fixed srand() makes rand() stable
@@ -143,7 +143,7 @@ end
 def fact_names_to_randomize
   total_facts = actual_facts_with_lengths.keys.size
   number_of_facts = (total_facts * (percent_to_change / 100.0)).to_i
-  stable_random_sublist(actual_facts_with_lengths.keys, number_of_facts)
+  stable_random_sublist(actual_facts_with_lengths.keys.sort, number_of_facts)
 end
 
 # Returns a Hash containing a list of real-world fact names as keys, with a
@@ -276,7 +276,8 @@ def sample_facts_with_lengths
   }
 end
 
-# get the list of facts which should be given random values
+# get the list of facts which should be given random values, make a Hash for
+# easily checking whether a name represents a randomized fact.
 randomized_facts = fact_names_to_randomize.inject({}) {|hash, name| hash[name] = true; hash }
 
 # for all facts for this agent, assign them values

--- a/lib/facter/lots_of_facts.rb
+++ b/lib/facter/lots_of_facts.rb
@@ -1,27 +1,227 @@
-# To compensate for our "fake" agents having virtually no facts,
-# generate some random facts. To better stress test puppetdb, (avoid its data
-# deduplication) these facts should:
+# To compensate for our non-root user agents having virtually no facts,
+# we generate facts here.  We allow the clamps configuration to dictate
+# how many facts are generated.
 #
-# contain different data each run
-# have the same fact name so we don't end up with 4 million facts in puppetdb
-# have verying length, to simulate things like SSH keys.
+# Since puppetdb can cache fact names and values, randomizing fact contents will
+# put more load on puppetdb.  Earlier implementations randomized all facts,
+# resulting in unrealistic scenarios for puppetdb.  We now expose the
+# percentage of fact randomization as a configuration setting as well.
 
-require 'securerandom'
-require 'facter'
+require "facter"
 
-num_facts = File.exist?('/etc/puppetlabs/clamps/num_facts') ? File.read('/etc/puppetlabs/clamps/num_facts').to_i : 500
-hash_of_facts = Hash.new {|h,k| h[k] = [] }
-
-for i in 1..num_facts
-  fact_value = ""
-  rand(1..50).times { fact_value << SecureRandom.hex }
-  hash_of_facts["fact_#{i}"] << fact_value
+# how many total facts were requested?
+def number_of_facts
+  @number_of_facts ||=
+    File.exist?("/etc/puppetlabs/clamps/num_facts") ?
+      File.read("/etc/puppetlabs/clamps/num_facts").to_i : 500
 end
 
-hash_of_facts.each_pair do |factname, factvalue|
-  Facter.add("clamps_#{factname}") do
+# what percentage of facts should we change on each run?
+def percent_to_change
+  @percent_to_change ||=
+    File.exist?("/etc/puppetlabs/clamps/percent_facts") ?
+      File.read("/etc/puppetlabs/clamps/percent_facts").to_i : 15
+end
+
+# A Hash containing a list of real-world-ish fact names as keys, with a sampled
+# real-world character length for that fact's value
+def sample_facts_with_lengths
+  {
+    "architecture" => 7,
+    "augeasversion" => 6,
+    "bios_release_date" => 11,
+    "bios_vendor" => 4,
+    "bios_version" => 11,
+    "blockdevice_xvda_size" => 11,
+    "blockdevices" => 5,
+    "domain" => 27,
+    "ec2_ami_id" => 13,
+    "ec2_ami_launch_index" => 2,
+    "ec2_ami_manifest_path" => 10,
+    "ec2_block_device_mapping_ami" => 10,
+    "ec2_block_device_mapping_root" => 10,
+    "ec2_hostname" => 43,
+    "ec2_instance_action" => 5,
+    "ec2_instance_id" => 11,
+    "ec2_instance_type" => 10,
+    "ec2_local_hostname" => 43,
+    "ec2_local_ipv4" => 13,
+    "ec2_mac" => 18,
+    "ec2_metadata" => 1931,
+    "ec2_metrics_vhostmd" => 39,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_device_number" => 2,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_interface_id" => 13,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_ipv4_associations_127.0.0.1" => 13,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_local_hostname" => 43,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_local_ipv4s" => 13,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_mac" => 18,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_owner_id" => 13,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_public_hostname" => 49,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_public_ipv4s" => 13,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_security_group_ids" => 12,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_security_groups" => 18,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_subnet_id" => 16,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_subnet_ipv4_cidr_block" => 15,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_vpc_id" => 13,
+    "ec2_network_interfaces_macs_12:34:56:78:90:ab_vpc_ipv4_cidr_block" => 14,
+    "ec2_placement_availability_zone" => 11,
+    "ec2_product_codes" => 26,
+    "ec2_profile" => 12,
+    "ec2_public_hostname" => 49,
+    "ec2_public_ipv4" => 13,
+    "ec2_public_keys_0_openssh_key" => 419,
+    "ec2_reservation_id" => 11,
+    "ec2_security_groups" => 18,
+    "ec2_services_domain" => 14,
+    "facterversion" => 6,
+    "filesystems" => 12,
+    "fqdn" => 34,
+    "gid" => 5,
+    "hardwareisa" => 7,
+    "hardwaremodel" => 7,
+    "hostname" => 7,
+    "id" => 5,
+    "interfaces" => 8,
+    "ipaddress" => 13,
+    "ipaddress_eth0" => 13,
+    "ipaddress_lo" => 10,
+    "is_virtual" => 5,
+    "kernel" => 6,
+    "kernelmajversion" => 5,
+    "kernelrelease" => 26,
+    "kernelversion" => 7,
+    "macaddress" => 18,
+    "macaddress_eth0" => 18,
+    "manufacturer" => 4,
+    "memoryfree" => 8,
+    "memoryfree_mb" => 8,
+    "memorysize" => 9,
+    "memorysize_mb" => 9,
+    "mtu_eth0" => 5,
+    "mtu_lo" => 6,
+    "netmask" => 14,
+    "netmask_eth0" => 14,
+    "netmask_lo" => 10,
+    "network_eth0" => 12,
+    "network_lo" => 10,
+    "operatingsystem" => 7,
+    "operatingsystemmajrelease" => 2,
+    "operatingsystemrelease" => 9,
+    "os" => 100,
+    "osfamily" => 7,
+    "partitions" => 115,
+    "path" => 82,
+    "physicalprocessorcount" => 2,
+    "processor0" => 42,
+    "processor1" => 42,
+    "processor2" => 42,
+    "processor3" => 42,
+    "processorcount" => 2,
+    "processors" => 225,
+    "productname" => 9,
+    "ps" => 7,
+    "puppetversion" => 32,
+    "rubyplatform" => 13,
+    "rubysitedir" => 37,
+    "rubyversion" => 6,
+    "selinux" => 5,
+    "selinux_config_mode" => 10,
+    "selinux_config_policy" => 8,
+    "selinux_current_mode" => 10,
+    "selinux_enforced" => 5,
+    "selinux_policyversion" => 3,
+    "serialnumber" => 37,
+    "sshecdsakey" => 141,
+    "sshfp_ecdsa" => 126,
+    "sshfp_rsa" => 126,
+    "sshrsakey" => 373,
+    "swapfree" => 8,
+    "swapfree_mb" => 5,
+    "swapsize" => 8,
+    "swapsize_mb" => 5,
+    "system_uptime" => 65,
+    "timezone" => 4,
+    "type" => 6,
+    "uniqueid" => 9,
+    "uptime" => 7,
+    "uptime_days" => 2,
+    "uptime_hours" => 4,
+    "uptime_seconds" => 7,
+    "uuid" => 37,
+    "virtual" => 7,
+  }
+end
+
+# Generate a Hash with `#number_of_facts` pairs: keys are fact names, of the
+# form "clamps_#{name}_#{index}" (e.g., "clamps_uptime_1") taken from
+# `#sample_facts_with_lengths`. Values are the "real-world" intended lengths
+# of a fact value for this key.
+def actual_facts_with_lengths
+  available = sample_facts_with_lengths.keys.sort
+  results = {}
+
+  pass = 1
+  0.upto(number_of_facts - 1) do |current|
+    fact_name = available[current % available.size]
+    results["clamps_#{fact_name}_#{pass}"] = sample_facts_with_lengths[fact_name]
+    pass += 1 if (current + 1) % available.size == 0
+  end
+
+  results
+end
+
+# Returns an alphanumeric (plus space) random string of length `length`
+def random_string(length)
+  charset = (('0'..'9').to_a + ('a'..'z').to_a + ('A' .. 'Z').to_a + [" "])
+  (0...length).map{ charset.to_a[rand(charset.size)] }.join
+end
+
+def fill_string(length)
+  "A" * length
+end
+
+def debugging?
+  !!ENV['DEBUG']
+end
+
+# Update Facter with the given fact name and value.
+def set_fact_value(name, value)
+  puts "setting fact [#{name}] to [#{value}]" if debugging?
+  Facter.add(name) do
     setcode do
-      factvalue[0]
+      value
     end
+  end
+end
+
+# Fisher-Yates shuffle a list
+# (http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle)
+def permute(list)
+  working = list.dup
+  0.upto(working.length - 2) do |index|
+    position = rand(working.length - index) + index
+    working[position], working[index] = working[index], working[position]
+  end
+  working
+end
+
+def fact_names_to_randomize
+  total_facts = actual_facts_with_lengths.keys.size
+  number_of_facts = (total_facts * (percent_to_change / 100.0)).to_i
+
+  # generate a stable permutation of `number_of_facts` fact names
+  srand(1234567890)
+  fact_names = permute(actual_facts_with_lengths.keys).take(number_of_facts)
+  srand
+  fact_names
+end
+
+randomized_facts = fact_names_to_randomize.inject({}) {|hash, name| hash[name] = true; hash }
+
+actual_facts_with_lengths.each_pair do |name, length|
+  if randomized_facts[name]
+    set_fact_value name, random_string(length)
+  else
+    set_fact_value name, fill_string(length)
   end
 end

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,16 +1,17 @@
 class clamps::agent (
-  $amqpass             = file('/etc/puppetlabs/mcollective/credentials'),
-  $amqserver           = [$::servername],
-  $ca                  = $::settings::ca_server,
-  $daemonize           = false,
-  $master              = $::servername,
-  $metrics_port        = 2003,
-  $metrics_server      = undef,
-  $nonroot_users       = '2',
-  $num_facts_per_agent = 500,
-  $shuffle_amq_servers = true,
-  $splay               = false,
-  $splaylimit          = undef,
+  $amqpass               = file('/etc/puppetlabs/mcollective/credentials'),
+  $amqserver             = [$::servername],
+  $ca                    = $::settings::ca_server,
+  $daemonize             = false,
+  $master                = $::servername,
+  $metrics_port          = 2003,
+  $metrics_server        = undef,
+  $nonroot_users         = '2',
+  $num_facts_per_agent   = 500,
+  $percent_changed_facts = 15,
+  $shuffle_amq_servers   = true,
+  $splay                 = false,
+  $splaylimit            = undef,
 ) {
 
   file { '/etc/puppetlabs/clamps':
@@ -20,6 +21,11 @@ class clamps::agent (
   file { '/etc/puppetlabs/clamps/num_facts':
     ensure  => file,
     content => $num_facts_per_agent,
+  }
+
+  file { '/etc/puppetlabs/clamps/percent_facts':
+    ensure  => file,
+    content => $percent_changed_facts,
   }
 
   $nonroot_usernames = clamps_users($nonroot_users)

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -20,12 +20,12 @@ class clamps::agent (
 
   file { '/etc/puppetlabs/clamps/num_facts':
     ensure  => file,
-    content => $num_facts_per_agent,
+    content => "${num_facts_per_agent}",
   }
 
   file { '/etc/puppetlabs/clamps/percent_facts':
     ensure  => file,
-    content => $percent_changed_facts,
+    content => "${percent_changed_facts}",
   }
 
   $nonroot_usernames = clamps_users($nonroot_users)


### PR DESCRIPTION
![](http://addins.whig.com/blogs/steviedirt/wp-content/uploads/2013/05/jack.jpg)

Prior to this, fact randomization generated long random values for every fact, with every value changing on every run.  This meant 100% fact churn, which ends up trashing the puppetdb cache (which ends up doing bad things to puppetdb).

Since the goal of CLAMPS is to provide load sufficient to exercise a puppet deployment, and to give confidence that if the running system falls over that it was not due to the artificial nature of testing, this prior approach was undesirable.

Here there are a few things happening:

 - We extracted a set of real-world fact names from an agent running on an EC2 node. We saved the lengths of the fact values. This allows us to generate facts and values with at least the length distributions we could expect to see in the real world.

 - We generate a list of clamps fact names that will be persistent across runs. For a given number of facts per agent (`#number_of_facts` in the source), the same list of fact names will always be generated. These will be in the form `clamps_factname_index` (e.g., "clamps_uptime_3"). This also implies a consistency across agents running independently -- i.e., if two agents are requested to have 100 facts, they will be the same 100 named facts on each agent.

 - Based upon configuration (`#percent_to_change` in the source), we choose a certain number of facts to receive random values each run. The names of the facts which get random values will be consistent between runs, and all other facts always have the same values. This will also actually be consistent between agents as well, provided the `#number_of_facts` and `#percent_to_change` values are set identically.

 - By choosing a fixed set of random fact names to change we avoid variation in churn. The alternative is that if a random 10% of facts are given random values, we are either forced to save old fact values between runs to avoid changing them (which introduces unwanted headaches), or we end up changing old "randomized" values back to some known fixed value while we randomize other fact values (which results in an inconsistent amount of change between runs). 

 - Our techniques here should also better simulate real-world behavior, where many facts never change over the lifetime of a node, and certain specific facts are known to change regularly, across most nodes.

**todo**

 - [x] more documentation, more code comments, a bit of cleanup
 - [x] manage the `percent_to_change` value
 - [x] currently blocked on an esoteric internal testing issue

/cc @ericwilliamson @doug-rosser @acidprime 