### PR TITLE
[QENG-2574] update CLAMPS for more recent puppets

### DIFF
--- a/ext/create_logic.rb
+++ b/ext/create_logic.rb
@@ -1,12 +1,22 @@
-(1..100).each do |i|
-  f = File.open("c_00#{i}.pp",'w')
-  if f
-    f.write("class #{ARGV[0]}::c_00#{i} \{\n\n")
-    f.write("include #{ARGV[0]}::c_00#{i - 1}\n\n")
-    (1..10).each do |j|
-      f.write("file \{\"/home/\${id}/#{i}_of_#{j}\": content => fqdn_rand(999999999999999999999999999999),\}\n\n")
+#!/usr/bin/env ruby
+
+# Generate the "logic" file resource puppet manifests, in `manifests/logic`.
+# The default class name is `clamps::logic` but can be overridden on the
+# command line.  The destination path can also be overridden on the command
+# line.
+
+classname  = ARGV.shift || "clamps::logic"
+destination = ARGV.shift || File.expand_path(File.join(File.dirname(__FILE__), "..", "manifests", "logic"))
+
+1.upto(100) do |i|
+  filename = File.join(destination, "c_00#{i}.pp")
+  File.open(filename,'w') do |f|
+    puts "Generating file [#{filename}]..."
+    f.puts "class #{classname}::c_00#{i} {\n\n"
+    f.puts "  include #{classname}::c_00#{i-1}\n\n"
+    1.upto(10) do |j|
+      f.puts %Q|  file {"/home/${id}/#{i}_of_#{j}\": content => "${fqdn_rand(999999999999999999999999999999)}",}|
     end
-    f.write("\}")
-  f.close()
+    f.puts "}"
   end
 end

--- a/ext/create_logic.rb
+++ b/ext/create_logic.rb
@@ -13,7 +13,7 @@ destination = ARGV.shift || File.expand_path(File.join(File.dirname(__FILE__), "
   File.open(filename,'w') do |f|
     puts "Generating file [#{filename}]..."
     f.puts "class #{classname}::c_00#{i} {\n\n"
-    f.puts "  include #{classname}::c_00#{i-1}\n\n"
+    f.puts "  include #{classname}::c_00#{i-1}\n\n" unless i == 1
     1.upto(10) do |j|
       f.puts %Q|  file {"/home/${id}/#{i}_of_#{j}\": content => "${fqdn_rand(999999999999999999999999999999)}",}|
     end

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -19,7 +19,7 @@ class clamps::agent (
 
   file { '/etc/puppetlabs/clamps/num_facts':
     ensure  => file,
-    content => $num_facts_per_agent,
+    content => "${num_facts_per_agent}",
   }
 
   $nonroot_usernames = clamps_users($nonroot_users)

--- a/manifests/logic/c_001.pp
+++ b/manifests/logic/c_001.pp
@@ -1,23 +1,15 @@
 class clamps::logic::c_001 {
 
-file {"/home/${id}/1_of_1": content => fqdn_rand(999999999999999999999999999999),}
+  include clamps::logic::c_000
 
-file {"/home/${id}/1_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/1_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/1_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/1_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/1_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/1_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/1_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/1_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/1_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/1_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/1_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/1_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/1_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/1_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/1_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/1_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/1_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/1_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/1_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_001.pp
+++ b/manifests/logic/c_001.pp
@@ -1,7 +1,5 @@
 class clamps::logic::c_001 {
 
-  include clamps::logic::c_000
-
   file {"/home/${id}/1_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
   file {"/home/${id}/1_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
   file {"/home/${id}/1_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}

--- a/manifests/logic/c_0010.pp
+++ b/manifests/logic/c_0010.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0010 {
 
-include clamps::logic::c_009
+  include clamps::logic::c_009
 
-file {"/home/${id}/10_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/10_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/10_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/10_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/10_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/10_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/10_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/10_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/10_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/10_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/10_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/10_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/10_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/10_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/10_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/10_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/10_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/10_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/10_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/10_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_00100.pp
+++ b/manifests/logic/c_00100.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_00100 {
 
-include clamps::logic::c_0099
+  include clamps::logic::c_0099
 
-file {"/home/${id}/100_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/100_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/100_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/100_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/100_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/100_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/100_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/100_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/100_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/100_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/100_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/100_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/100_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/100_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/100_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/100_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/100_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/100_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/100_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/100_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0011.pp
+++ b/manifests/logic/c_0011.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0011 {
 
-include clamps::logic::c_0010
+  include clamps::logic::c_0010
 
-file {"/home/${id}/11_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/11_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/11_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/11_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/11_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/11_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/11_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/11_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/11_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/11_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/11_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/11_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/11_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/11_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/11_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/11_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/11_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/11_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/11_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/11_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0012.pp
+++ b/manifests/logic/c_0012.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0012 {
 
-include clamps::logic::c_0011
+  include clamps::logic::c_0011
 
-file {"/home/${id}/12_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/12_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/12_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/12_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/12_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/12_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/12_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/12_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/12_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/12_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/12_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/12_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/12_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/12_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/12_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/12_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/12_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/12_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/12_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/12_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0013.pp
+++ b/manifests/logic/c_0013.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0013 {
 
-include clamps::logic::c_0012
+  include clamps::logic::c_0012
 
-file {"/home/${id}/13_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/13_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/13_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/13_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/13_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/13_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/13_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/13_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/13_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/13_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/13_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/13_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/13_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/13_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/13_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/13_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/13_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/13_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/13_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/13_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0014.pp
+++ b/manifests/logic/c_0014.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0014 {
 
-include clamps::logic::c_0013
+  include clamps::logic::c_0013
 
-file {"/home/${id}/14_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/14_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/14_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/14_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/14_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/14_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/14_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/14_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/14_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/14_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/14_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/14_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/14_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/14_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/14_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/14_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/14_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/14_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/14_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/14_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0015.pp
+++ b/manifests/logic/c_0015.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0015 {
 
-include clamps::logic::c_0014
+  include clamps::logic::c_0014
 
-file {"/home/${id}/15_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/15_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/15_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/15_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/15_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/15_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/15_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/15_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/15_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/15_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/15_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/15_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/15_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/15_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/15_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/15_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/15_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/15_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/15_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/15_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0016.pp
+++ b/manifests/logic/c_0016.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0016 {
 
-include clamps::logic::c_0015
+  include clamps::logic::c_0015
 
-file {"/home/${id}/16_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/16_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/16_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/16_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/16_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/16_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/16_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/16_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/16_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/16_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/16_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/16_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/16_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/16_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/16_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/16_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/16_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/16_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/16_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/16_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0017.pp
+++ b/manifests/logic/c_0017.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0017 {
 
-include clamps::logic::c_0016
+  include clamps::logic::c_0016
 
-file {"/home/${id}/17_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/17_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/17_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/17_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/17_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/17_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/17_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/17_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/17_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/17_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/17_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/17_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/17_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/17_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/17_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/17_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/17_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/17_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/17_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/17_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0018.pp
+++ b/manifests/logic/c_0018.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0018 {
 
-include clamps::logic::c_0017
+  include clamps::logic::c_0017
 
-file {"/home/${id}/18_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/18_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/18_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/18_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/18_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/18_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/18_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/18_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/18_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/18_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/18_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/18_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/18_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/18_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/18_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/18_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/18_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/18_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/18_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/18_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0019.pp
+++ b/manifests/logic/c_0019.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0019 {
 
-include clamps::logic::c_0018
+  include clamps::logic::c_0018
 
-file {"/home/${id}/19_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/19_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/19_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/19_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/19_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/19_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/19_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/19_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/19_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/19_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/19_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/19_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/19_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/19_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/19_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/19_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/19_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/19_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/19_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/19_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_002.pp
+++ b/manifests/logic/c_002.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_002 {
 
-include clamps::logic::c_001
+  include clamps::logic::c_001
 
-file {"/home/${id}/2_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/2_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/2_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/2_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/2_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/2_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/2_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/2_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/2_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/2_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/2_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/2_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/2_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/2_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/2_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/2_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/2_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/2_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/2_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/2_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0020.pp
+++ b/manifests/logic/c_0020.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0020 {
 
-include clamps::logic::c_0019
+  include clamps::logic::c_0019
 
-file {"/home/${id}/20_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/20_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/20_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/20_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/20_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/20_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/20_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/20_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/20_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/20_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/20_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/20_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/20_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/20_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/20_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/20_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/20_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/20_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/20_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/20_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0021.pp
+++ b/manifests/logic/c_0021.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0021 {
 
-include clamps::logic::c_0020
+  include clamps::logic::c_0020
 
-file {"/home/${id}/21_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/21_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/21_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/21_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/21_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/21_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/21_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/21_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/21_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/21_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/21_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/21_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/21_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/21_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/21_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/21_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/21_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/21_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/21_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/21_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0022.pp
+++ b/manifests/logic/c_0022.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0022 {
 
-include clamps::logic::c_0021
+  include clamps::logic::c_0021
 
-file {"/home/${id}/22_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/22_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/22_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/22_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/22_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/22_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/22_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/22_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/22_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/22_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/22_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/22_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/22_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/22_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/22_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/22_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/22_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/22_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/22_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/22_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0023.pp
+++ b/manifests/logic/c_0023.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0023 {
 
-include clamps::logic::c_0022
+  include clamps::logic::c_0022
 
-file {"/home/${id}/23_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/23_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/23_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/23_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/23_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/23_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/23_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/23_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/23_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/23_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/23_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/23_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/23_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/23_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/23_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/23_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/23_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/23_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/23_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/23_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0024.pp
+++ b/manifests/logic/c_0024.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0024 {
 
-include clamps::logic::c_0023
+  include clamps::logic::c_0023
 
-file {"/home/${id}/24_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/24_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/24_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/24_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/24_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/24_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/24_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/24_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/24_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/24_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/24_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/24_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/24_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/24_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/24_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/24_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/24_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/24_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/24_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/24_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0025.pp
+++ b/manifests/logic/c_0025.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0025 {
 
-include clamps::logic::c_0024
+  include clamps::logic::c_0024
 
-file {"/home/${id}/25_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/25_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/25_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/25_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/25_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/25_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/25_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/25_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/25_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/25_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/25_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/25_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/25_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/25_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/25_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/25_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/25_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/25_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/25_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/25_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0026.pp
+++ b/manifests/logic/c_0026.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0026 {
 
-include clamps::logic::c_0025
+  include clamps::logic::c_0025
 
-file {"/home/${id}/26_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/26_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/26_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/26_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/26_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/26_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/26_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/26_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/26_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/26_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/26_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/26_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/26_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/26_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/26_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/26_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/26_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/26_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/26_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/26_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0027.pp
+++ b/manifests/logic/c_0027.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0027 {
 
-include clamps::logic::c_0026
+  include clamps::logic::c_0026
 
-file {"/home/${id}/27_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/27_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/27_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/27_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/27_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/27_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/27_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/27_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/27_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/27_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/27_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/27_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/27_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/27_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/27_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/27_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/27_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/27_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/27_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/27_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0028.pp
+++ b/manifests/logic/c_0028.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0028 {
 
-include clamps::logic::c_0027
+  include clamps::logic::c_0027
 
-file {"/home/${id}/28_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/28_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/28_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/28_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/28_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/28_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/28_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/28_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/28_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/28_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/28_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/28_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/28_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/28_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/28_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/28_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/28_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/28_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/28_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/28_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0029.pp
+++ b/manifests/logic/c_0029.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0029 {
 
-include clamps::logic::c_0028
+  include clamps::logic::c_0028
 
-file {"/home/${id}/29_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/29_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/29_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/29_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/29_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/29_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/29_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/29_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/29_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/29_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/29_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/29_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/29_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/29_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/29_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/29_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/29_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/29_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/29_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/29_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_003.pp
+++ b/manifests/logic/c_003.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_003 {
 
-include clamps::logic::c_002
+  include clamps::logic::c_002
 
-file {"/home/${id}/3_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/3_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/3_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/3_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/3_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/3_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/3_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/3_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/3_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/3_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/3_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/3_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/3_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/3_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/3_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/3_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/3_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/3_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/3_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/3_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0030.pp
+++ b/manifests/logic/c_0030.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0030 {
 
-include clamps::logic::c_0029
+  include clamps::logic::c_0029
 
-file {"/home/${id}/30_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/30_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/30_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/30_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/30_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/30_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/30_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/30_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/30_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/30_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/30_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/30_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/30_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/30_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/30_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/30_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/30_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/30_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/30_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/30_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0031.pp
+++ b/manifests/logic/c_0031.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0031 {
 
-include clamps::logic::c_0030
+  include clamps::logic::c_0030
 
-file {"/home/${id}/31_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/31_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/31_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/31_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/31_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/31_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/31_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/31_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/31_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/31_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/31_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/31_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/31_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/31_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/31_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/31_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/31_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/31_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/31_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/31_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0032.pp
+++ b/manifests/logic/c_0032.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0032 {
 
-include clamps::logic::c_0031
+  include clamps::logic::c_0031
 
-file {"/home/${id}/32_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/32_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/32_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/32_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/32_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/32_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/32_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/32_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/32_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/32_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/32_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/32_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/32_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/32_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/32_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/32_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/32_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/32_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/32_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/32_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0033.pp
+++ b/manifests/logic/c_0033.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0033 {
 
-include clamps::logic::c_0032
+  include clamps::logic::c_0032
 
-file {"/home/${id}/33_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/33_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/33_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/33_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/33_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/33_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/33_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/33_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/33_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/33_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/33_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/33_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/33_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/33_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/33_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/33_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/33_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/33_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/33_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/33_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0034.pp
+++ b/manifests/logic/c_0034.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0034 {
 
-include clamps::logic::c_0033
+  include clamps::logic::c_0033
 
-file {"/home/${id}/34_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/34_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/34_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/34_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/34_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/34_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/34_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/34_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/34_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/34_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/34_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/34_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/34_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/34_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/34_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/34_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/34_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/34_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/34_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/34_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0035.pp
+++ b/manifests/logic/c_0035.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0035 {
 
-include clamps::logic::c_0034
+  include clamps::logic::c_0034
 
-file {"/home/${id}/35_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/35_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/35_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/35_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/35_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/35_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/35_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/35_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/35_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/35_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/35_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/35_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/35_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/35_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/35_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/35_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/35_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/35_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/35_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/35_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0036.pp
+++ b/manifests/logic/c_0036.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0036 {
 
-include clamps::logic::c_0035
+  include clamps::logic::c_0035
 
-file {"/home/${id}/36_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/36_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/36_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/36_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/36_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/36_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/36_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/36_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/36_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/36_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/36_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/36_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/36_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/36_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/36_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/36_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/36_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/36_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/36_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/36_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0037.pp
+++ b/manifests/logic/c_0037.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0037 {
 
-include clamps::logic::c_0036
+  include clamps::logic::c_0036
 
-file {"/home/${id}/37_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/37_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/37_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/37_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/37_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/37_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/37_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/37_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/37_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/37_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/37_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/37_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/37_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/37_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/37_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/37_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/37_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/37_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/37_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/37_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0038.pp
+++ b/manifests/logic/c_0038.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0038 {
 
-include clamps::logic::c_0037
+  include clamps::logic::c_0037
 
-file {"/home/${id}/38_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/38_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/38_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/38_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/38_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/38_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/38_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/38_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/38_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/38_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/38_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/38_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/38_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/38_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/38_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/38_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/38_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/38_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/38_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/38_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0039.pp
+++ b/manifests/logic/c_0039.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0039 {
 
-include clamps::logic::c_0038
+  include clamps::logic::c_0038
 
-file {"/home/${id}/39_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/39_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/39_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/39_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/39_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/39_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/39_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/39_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/39_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/39_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/39_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/39_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/39_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/39_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/39_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/39_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/39_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/39_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/39_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/39_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_004.pp
+++ b/manifests/logic/c_004.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_004 {
 
-include clamps::logic::c_003
+  include clamps::logic::c_003
 
-file {"/home/${id}/4_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/4_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/4_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/4_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/4_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/4_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/4_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/4_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/4_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/4_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/4_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/4_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/4_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/4_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/4_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/4_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/4_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/4_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/4_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/4_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0040.pp
+++ b/manifests/logic/c_0040.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0040 {
 
-include clamps::logic::c_0039
+  include clamps::logic::c_0039
 
-file {"/home/${id}/40_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/40_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/40_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/40_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/40_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/40_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/40_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/40_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/40_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/40_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/40_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/40_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/40_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/40_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/40_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/40_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/40_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/40_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/40_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/40_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0041.pp
+++ b/manifests/logic/c_0041.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0041 {
 
-include clamps::logic::c_0040
+  include clamps::logic::c_0040
 
-file {"/home/${id}/41_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/41_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/41_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/41_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/41_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/41_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/41_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/41_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/41_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/41_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/41_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/41_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/41_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/41_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/41_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/41_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/41_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/41_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/41_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/41_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0042.pp
+++ b/manifests/logic/c_0042.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0042 {
 
-include clamps::logic::c_0041
+  include clamps::logic::c_0041
 
-file {"/home/${id}/42_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/42_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/42_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/42_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/42_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/42_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/42_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/42_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/42_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/42_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/42_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/42_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/42_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/42_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/42_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/42_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/42_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/42_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/42_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/42_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0043.pp
+++ b/manifests/logic/c_0043.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0043 {
 
-include clamps::logic::c_0042
+  include clamps::logic::c_0042
 
-file {"/home/${id}/43_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/43_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/43_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/43_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/43_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/43_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/43_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/43_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/43_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/43_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/43_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/43_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/43_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/43_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/43_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/43_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/43_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/43_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/43_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/43_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0044.pp
+++ b/manifests/logic/c_0044.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0044 {
 
-include clamps::logic::c_0043
+  include clamps::logic::c_0043
 
-file {"/home/${id}/44_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/44_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/44_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/44_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/44_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/44_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/44_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/44_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/44_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/44_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/44_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/44_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/44_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/44_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/44_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/44_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/44_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/44_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/44_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/44_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0045.pp
+++ b/manifests/logic/c_0045.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0045 {
 
-include clamps::logic::c_0044
+  include clamps::logic::c_0044
 
-file {"/home/${id}/45_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/45_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/45_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/45_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/45_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/45_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/45_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/45_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/45_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/45_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/45_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/45_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/45_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/45_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/45_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/45_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/45_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/45_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/45_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/45_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0046.pp
+++ b/manifests/logic/c_0046.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0046 {
 
-include clamps::logic::c_0045
+  include clamps::logic::c_0045
 
-file {"/home/${id}/46_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/46_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/46_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/46_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/46_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/46_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/46_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/46_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/46_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/46_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/46_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/46_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/46_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/46_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/46_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/46_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/46_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/46_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/46_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/46_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0047.pp
+++ b/manifests/logic/c_0047.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0047 {
 
-include clamps::logic::c_0046
+  include clamps::logic::c_0046
 
-file {"/home/${id}/47_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/47_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/47_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/47_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/47_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/47_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/47_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/47_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/47_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/47_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/47_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/47_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/47_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/47_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/47_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/47_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/47_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/47_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/47_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/47_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0048.pp
+++ b/manifests/logic/c_0048.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0048 {
 
-include clamps::logic::c_0047
+  include clamps::logic::c_0047
 
-file {"/home/${id}/48_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/48_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/48_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/48_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/48_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/48_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/48_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/48_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/48_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/48_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/48_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/48_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/48_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/48_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/48_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/48_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/48_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/48_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/48_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/48_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0049.pp
+++ b/manifests/logic/c_0049.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0049 {
 
-include clamps::logic::c_0048
+  include clamps::logic::c_0048
 
-file {"/home/${id}/49_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/49_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/49_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/49_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/49_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/49_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/49_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/49_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/49_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/49_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/49_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/49_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/49_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/49_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/49_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/49_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/49_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/49_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/49_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/49_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_005.pp
+++ b/manifests/logic/c_005.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_005 {
 
-include clamps::logic::c_004
+  include clamps::logic::c_004
 
-file {"/home/${id}/5_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/5_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/5_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/5_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/5_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/5_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/5_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/5_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/5_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/5_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/5_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/5_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/5_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/5_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/5_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/5_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/5_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/5_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/5_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/5_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0050.pp
+++ b/manifests/logic/c_0050.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0050 {
 
-include clamps::logic::c_0049
+  include clamps::logic::c_0049
 
-file {"/home/${id}/50_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/50_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/50_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/50_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/50_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/50_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/50_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/50_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/50_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/50_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/50_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/50_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/50_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/50_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/50_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/50_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/50_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/50_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/50_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/50_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0051.pp
+++ b/manifests/logic/c_0051.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0051 {
 
-include clamps::logic::c_0050
+  include clamps::logic::c_0050
 
-file {"/home/${id}/51_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/51_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/51_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/51_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/51_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/51_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/51_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/51_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/51_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/51_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/51_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/51_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/51_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/51_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/51_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/51_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/51_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/51_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/51_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/51_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0052.pp
+++ b/manifests/logic/c_0052.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0052 {
 
-include clamps::logic::c_0051
+  include clamps::logic::c_0051
 
-file {"/home/${id}/52_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/52_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/52_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/52_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/52_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/52_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/52_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/52_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/52_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/52_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/52_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/52_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/52_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/52_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/52_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/52_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/52_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/52_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/52_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/52_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0053.pp
+++ b/manifests/logic/c_0053.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0053 {
 
-include clamps::logic::c_0052
+  include clamps::logic::c_0052
 
-file {"/home/${id}/53_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/53_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/53_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/53_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/53_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/53_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/53_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/53_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/53_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/53_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/53_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/53_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/53_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/53_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/53_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/53_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/53_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/53_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/53_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/53_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0054.pp
+++ b/manifests/logic/c_0054.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0054 {
 
-include clamps::logic::c_0053
+  include clamps::logic::c_0053
 
-file {"/home/${id}/54_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/54_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/54_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/54_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/54_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/54_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/54_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/54_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/54_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/54_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/54_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/54_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/54_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/54_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/54_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/54_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/54_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/54_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/54_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/54_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0055.pp
+++ b/manifests/logic/c_0055.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0055 {
 
-include clamps::logic::c_0054
+  include clamps::logic::c_0054
 
-file {"/home/${id}/55_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/55_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/55_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/55_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/55_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/55_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/55_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/55_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/55_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/55_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/55_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/55_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/55_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/55_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/55_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/55_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/55_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/55_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/55_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/55_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0056.pp
+++ b/manifests/logic/c_0056.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0056 {
 
-include clamps::logic::c_0055
+  include clamps::logic::c_0055
 
-file {"/home/${id}/56_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/56_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/56_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/56_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/56_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/56_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/56_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/56_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/56_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/56_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/56_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/56_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/56_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/56_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/56_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/56_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/56_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/56_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/56_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/56_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0057.pp
+++ b/manifests/logic/c_0057.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0057 {
 
-include clamps::logic::c_0056
+  include clamps::logic::c_0056
 
-file {"/home/${id}/57_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/57_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/57_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/57_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/57_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/57_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/57_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/57_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/57_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/57_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/57_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/57_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/57_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/57_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/57_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/57_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/57_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/57_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/57_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/57_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0058.pp
+++ b/manifests/logic/c_0058.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0058 {
 
-include clamps::logic::c_0057
+  include clamps::logic::c_0057
 
-file {"/home/${id}/58_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/58_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/58_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/58_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/58_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/58_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/58_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/58_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/58_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/58_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/58_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/58_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/58_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/58_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/58_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/58_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/58_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/58_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/58_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/58_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0059.pp
+++ b/manifests/logic/c_0059.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0059 {
 
-include clamps::logic::c_0058
+  include clamps::logic::c_0058
 
-file {"/home/${id}/59_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/59_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/59_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/59_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/59_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/59_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/59_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/59_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/59_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/59_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/59_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/59_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/59_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/59_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/59_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/59_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/59_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/59_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/59_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/59_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_006.pp
+++ b/manifests/logic/c_006.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_006 {
 
-include clamps::logic::c_005
+  include clamps::logic::c_005
 
-file {"/home/${id}/6_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/6_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/6_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/6_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/6_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/6_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/6_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/6_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/6_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/6_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/6_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/6_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/6_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/6_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/6_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/6_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/6_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/6_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/6_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/6_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0060.pp
+++ b/manifests/logic/c_0060.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0060 {
 
-include clamps::logic::c_0059
+  include clamps::logic::c_0059
 
-file {"/home/${id}/60_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/60_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/60_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/60_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/60_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/60_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/60_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/60_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/60_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/60_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/60_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/60_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/60_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/60_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/60_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/60_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/60_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/60_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/60_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/60_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0061.pp
+++ b/manifests/logic/c_0061.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0061 {
 
-include clamps::logic::c_0060
+  include clamps::logic::c_0060
 
-file {"/home/${id}/61_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/61_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/61_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/61_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/61_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/61_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/61_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/61_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/61_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/61_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/61_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/61_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/61_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/61_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/61_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/61_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/61_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/61_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/61_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/61_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0062.pp
+++ b/manifests/logic/c_0062.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0062 {
 
-include clamps::logic::c_0061
+  include clamps::logic::c_0061
 
-file {"/home/${id}/62_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/62_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/62_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/62_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/62_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/62_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/62_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/62_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/62_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/62_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/62_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/62_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/62_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/62_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/62_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/62_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/62_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/62_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/62_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/62_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0063.pp
+++ b/manifests/logic/c_0063.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0063 {
 
-include clamps::logic::c_0062
+  include clamps::logic::c_0062
 
-file {"/home/${id}/63_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/63_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/63_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/63_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/63_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/63_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/63_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/63_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/63_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/63_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/63_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/63_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/63_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/63_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/63_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/63_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/63_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/63_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/63_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/63_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0064.pp
+++ b/manifests/logic/c_0064.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0064 {
 
-include clamps::logic::c_0063
+  include clamps::logic::c_0063
 
-file {"/home/${id}/64_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/64_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/64_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/64_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/64_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/64_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/64_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/64_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/64_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/64_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/64_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/64_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/64_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/64_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/64_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/64_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/64_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/64_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/64_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/64_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0065.pp
+++ b/manifests/logic/c_0065.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0065 {
 
-include clamps::logic::c_0064
+  include clamps::logic::c_0064
 
-file {"/home/${id}/65_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/65_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/65_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/65_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/65_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/65_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/65_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/65_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/65_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/65_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/65_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/65_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/65_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/65_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/65_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/65_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/65_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/65_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/65_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/65_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0066.pp
+++ b/manifests/logic/c_0066.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0066 {
 
-include clamps::logic::c_0065
+  include clamps::logic::c_0065
 
-file {"/home/${id}/66_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/66_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/66_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/66_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/66_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/66_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/66_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/66_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/66_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/66_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/66_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/66_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/66_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/66_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/66_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/66_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/66_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/66_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/66_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/66_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0067.pp
+++ b/manifests/logic/c_0067.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0067 {
 
-include clamps::logic::c_0066
+  include clamps::logic::c_0066
 
-file {"/home/${id}/67_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/67_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/67_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/67_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/67_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/67_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/67_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/67_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/67_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/67_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/67_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/67_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/67_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/67_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/67_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/67_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/67_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/67_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/67_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/67_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0068.pp
+++ b/manifests/logic/c_0068.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0068 {
 
-include clamps::logic::c_0067
+  include clamps::logic::c_0067
 
-file {"/home/${id}/68_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/68_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/68_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/68_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/68_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/68_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/68_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/68_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/68_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/68_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/68_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/68_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/68_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/68_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/68_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/68_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/68_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/68_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/68_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/68_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0069.pp
+++ b/manifests/logic/c_0069.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0069 {
 
-include clamps::logic::c_0068
+  include clamps::logic::c_0068
 
-file {"/home/${id}/69_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/69_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/69_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/69_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/69_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/69_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/69_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/69_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/69_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/69_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/69_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/69_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/69_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/69_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/69_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/69_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/69_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/69_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/69_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/69_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_007.pp
+++ b/manifests/logic/c_007.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_007 {
 
-include clamps::logic::c_006
+  include clamps::logic::c_006
 
-file {"/home/${id}/7_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/7_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/7_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/7_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/7_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/7_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/7_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/7_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/7_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/7_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/7_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/7_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/7_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/7_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/7_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/7_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/7_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/7_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/7_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/7_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0070.pp
+++ b/manifests/logic/c_0070.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0070 {
 
-include clamps::logic::c_0069
+  include clamps::logic::c_0069
 
-file {"/home/${id}/70_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/70_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/70_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/70_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/70_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/70_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/70_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/70_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/70_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/70_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/70_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/70_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/70_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/70_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/70_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/70_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/70_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/70_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/70_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/70_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0071.pp
+++ b/manifests/logic/c_0071.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0071 {
 
-include clamps::logic::c_0070
+  include clamps::logic::c_0070
 
-file {"/home/${id}/71_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/71_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/71_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/71_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/71_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/71_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/71_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/71_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/71_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/71_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/71_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/71_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/71_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/71_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/71_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/71_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/71_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/71_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/71_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/71_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0072.pp
+++ b/manifests/logic/c_0072.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0072 {
 
-include clamps::logic::c_0071
+  include clamps::logic::c_0071
 
-file {"/home/${id}/72_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/72_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/72_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/72_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/72_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/72_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/72_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/72_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/72_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/72_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/72_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/72_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/72_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/72_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/72_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/72_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/72_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/72_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/72_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/72_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0073.pp
+++ b/manifests/logic/c_0073.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0073 {
 
-include clamps::logic::c_0072
+  include clamps::logic::c_0072
 
-file {"/home/${id}/73_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/73_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/73_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/73_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/73_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/73_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/73_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/73_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/73_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/73_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/73_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/73_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/73_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/73_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/73_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/73_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/73_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/73_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/73_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/73_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0074.pp
+++ b/manifests/logic/c_0074.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0074 {
 
-include clamps::logic::c_0073
+  include clamps::logic::c_0073
 
-file {"/home/${id}/74_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/74_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/74_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/74_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/74_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/74_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/74_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/74_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/74_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/74_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/74_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/74_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/74_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/74_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/74_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/74_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/74_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/74_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/74_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/74_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0075.pp
+++ b/manifests/logic/c_0075.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0075 {
 
-include clamps::logic::c_0074
+  include clamps::logic::c_0074
 
-file {"/home/${id}/75_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/75_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/75_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/75_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/75_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/75_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/75_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/75_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/75_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/75_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/75_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/75_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/75_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/75_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/75_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/75_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/75_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/75_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/75_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/75_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0076.pp
+++ b/manifests/logic/c_0076.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0076 {
 
-include clamps::logic::c_0075
+  include clamps::logic::c_0075
 
-file {"/home/${id}/76_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/76_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/76_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/76_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/76_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/76_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/76_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/76_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/76_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/76_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/76_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/76_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/76_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/76_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/76_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/76_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/76_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/76_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/76_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/76_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0077.pp
+++ b/manifests/logic/c_0077.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0077 {
 
-include clamps::logic::c_0076
+  include clamps::logic::c_0076
 
-file {"/home/${id}/77_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/77_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/77_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/77_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/77_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/77_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/77_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/77_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/77_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/77_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/77_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/77_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/77_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/77_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/77_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/77_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/77_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/77_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/77_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/77_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0078.pp
+++ b/manifests/logic/c_0078.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0078 {
 
-include clamps::logic::c_0077
+  include clamps::logic::c_0077
 
-file {"/home/${id}/78_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/78_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/78_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/78_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/78_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/78_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/78_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/78_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/78_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/78_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/78_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/78_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/78_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/78_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/78_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/78_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/78_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/78_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/78_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/78_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0079.pp
+++ b/manifests/logic/c_0079.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0079 {
 
-include clamps::logic::c_0078
+  include clamps::logic::c_0078
 
-file {"/home/${id}/79_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/79_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/79_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/79_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/79_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/79_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/79_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/79_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/79_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/79_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/79_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/79_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/79_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/79_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/79_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/79_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/79_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/79_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/79_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/79_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_008.pp
+++ b/manifests/logic/c_008.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_008 {
 
-include clamps::logic::c_007
+  include clamps::logic::c_007
 
-file {"/home/${id}/8_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/8_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/8_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/8_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/8_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/8_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/8_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/8_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/8_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/8_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/8_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/8_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/8_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/8_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/8_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/8_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/8_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/8_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/8_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/8_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0080.pp
+++ b/manifests/logic/c_0080.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0080 {
 
-include clamps::logic::c_0079
+  include clamps::logic::c_0079
 
-file {"/home/${id}/80_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/80_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/80_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/80_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/80_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/80_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/80_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/80_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/80_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/80_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/80_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/80_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/80_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/80_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/80_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/80_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/80_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/80_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/80_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/80_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0081.pp
+++ b/manifests/logic/c_0081.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0081 {
 
-include clamps::logic::c_0080
+  include clamps::logic::c_0080
 
-file {"/home/${id}/81_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/81_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/81_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/81_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/81_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/81_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/81_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/81_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/81_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/81_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/81_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/81_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/81_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/81_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/81_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/81_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/81_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/81_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/81_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/81_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0082.pp
+++ b/manifests/logic/c_0082.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0082 {
 
-include clamps::logic::c_0081
+  include clamps::logic::c_0081
 
-file {"/home/${id}/82_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/82_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/82_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/82_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/82_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/82_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/82_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/82_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/82_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/82_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/82_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/82_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/82_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/82_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/82_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/82_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/82_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/82_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/82_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/82_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0083.pp
+++ b/manifests/logic/c_0083.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0083 {
 
-include clamps::logic::c_0082
+  include clamps::logic::c_0082
 
-file {"/home/${id}/83_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/83_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/83_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/83_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/83_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/83_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/83_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/83_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/83_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/83_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/83_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/83_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/83_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/83_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/83_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/83_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/83_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/83_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/83_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/83_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0084.pp
+++ b/manifests/logic/c_0084.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0084 {
 
-include clamps::logic::c_0083
+  include clamps::logic::c_0083
 
-file {"/home/${id}/84_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/84_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/84_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/84_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/84_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/84_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/84_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/84_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/84_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/84_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/84_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/84_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/84_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/84_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/84_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/84_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/84_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/84_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/84_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/84_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0085.pp
+++ b/manifests/logic/c_0085.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0085 {
 
-include clamps::logic::c_0084
+  include clamps::logic::c_0084
 
-file {"/home/${id}/85_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/85_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/85_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/85_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/85_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/85_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/85_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/85_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/85_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/85_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/85_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/85_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/85_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/85_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/85_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/85_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/85_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/85_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/85_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/85_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0086.pp
+++ b/manifests/logic/c_0086.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0086 {
 
-include clamps::logic::c_0085
+  include clamps::logic::c_0085
 
-file {"/home/${id}/86_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/86_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/86_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/86_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/86_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/86_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/86_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/86_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/86_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/86_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/86_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/86_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/86_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/86_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/86_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/86_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/86_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/86_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/86_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/86_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0087.pp
+++ b/manifests/logic/c_0087.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0087 {
 
-include clamps::logic::c_0086
+  include clamps::logic::c_0086
 
-file {"/home/${id}/87_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/87_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/87_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/87_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/87_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/87_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/87_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/87_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/87_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/87_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/87_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/87_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/87_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/87_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/87_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/87_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/87_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/87_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/87_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/87_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0088.pp
+++ b/manifests/logic/c_0088.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0088 {
 
-include clamps::logic::c_0087
+  include clamps::logic::c_0087
 
-file {"/home/${id}/88_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/88_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/88_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/88_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/88_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/88_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/88_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/88_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/88_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/88_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/88_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/88_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/88_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/88_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/88_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/88_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/88_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/88_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/88_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/88_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0089.pp
+++ b/manifests/logic/c_0089.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0089 {
 
-include clamps::logic::c_0088
+  include clamps::logic::c_0088
 
-file {"/home/${id}/89_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/89_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/89_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/89_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/89_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/89_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/89_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/89_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/89_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/89_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/89_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/89_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/89_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/89_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/89_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/89_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/89_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/89_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/89_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/89_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_009.pp
+++ b/manifests/logic/c_009.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_009 {
 
-include clamps::logic::c_008
+  include clamps::logic::c_008
 
-file {"/home/${id}/9_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/9_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/9_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/9_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/9_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/9_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/9_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/9_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/9_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/9_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/9_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/9_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/9_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/9_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/9_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/9_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/9_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/9_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/9_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/9_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0090.pp
+++ b/manifests/logic/c_0090.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0090 {
 
-include clamps::logic::c_0089
+  include clamps::logic::c_0089
 
-file {"/home/${id}/90_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/90_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/90_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/90_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/90_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/90_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/90_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/90_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/90_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/90_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/90_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/90_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/90_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/90_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/90_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/90_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/90_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/90_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/90_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/90_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0091.pp
+++ b/manifests/logic/c_0091.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0091 {
 
-include clamps::logic::c_0090
+  include clamps::logic::c_0090
 
-file {"/home/${id}/91_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/91_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/91_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/91_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/91_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/91_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/91_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/91_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/91_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/91_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/91_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/91_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/91_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/91_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/91_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/91_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/91_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/91_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/91_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/91_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0092.pp
+++ b/manifests/logic/c_0092.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0092 {
 
-include clamps::logic::c_0091
+  include clamps::logic::c_0091
 
-file {"/home/${id}/92_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/92_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/92_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/92_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/92_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/92_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/92_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/92_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/92_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/92_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/92_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/92_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/92_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/92_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/92_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/92_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/92_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/92_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/92_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/92_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0093.pp
+++ b/manifests/logic/c_0093.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0093 {
 
-include clamps::logic::c_0092
+  include clamps::logic::c_0092
 
-file {"/home/${id}/93_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/93_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/93_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/93_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/93_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/93_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/93_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/93_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/93_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/93_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/93_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/93_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/93_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/93_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/93_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/93_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/93_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/93_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/93_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/93_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0094.pp
+++ b/manifests/logic/c_0094.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0094 {
 
-include clamps::logic::c_0093
+  include clamps::logic::c_0093
 
-file {"/home/${id}/94_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/94_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/94_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/94_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/94_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/94_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/94_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/94_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/94_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/94_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/94_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/94_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/94_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/94_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/94_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/94_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/94_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/94_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/94_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/94_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0095.pp
+++ b/manifests/logic/c_0095.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0095 {
 
-include clamps::logic::c_0094
+  include clamps::logic::c_0094
 
-file {"/home/${id}/95_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/95_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/95_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/95_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/95_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/95_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/95_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/95_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/95_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/95_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/95_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/95_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/95_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/95_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/95_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/95_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/95_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/95_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/95_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/95_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0096.pp
+++ b/manifests/logic/c_0096.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0096 {
 
-include clamps::logic::c_0095
+  include clamps::logic::c_0095
 
-file {"/home/${id}/96_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/96_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/96_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/96_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/96_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/96_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/96_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/96_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/96_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/96_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/96_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/96_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/96_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/96_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/96_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/96_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/96_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/96_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/96_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/96_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0097.pp
+++ b/manifests/logic/c_0097.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0097 {
 
-include clamps::logic::c_0096
+  include clamps::logic::c_0096
 
-file {"/home/${id}/97_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/97_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/97_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/97_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/97_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/97_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/97_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/97_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/97_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/97_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/97_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/97_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/97_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/97_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/97_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/97_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/97_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/97_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/97_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/97_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0098.pp
+++ b/manifests/logic/c_0098.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0098 {
 
-include clamps::logic::c_0097
+  include clamps::logic::c_0097
 
-file {"/home/${id}/98_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/98_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/98_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/98_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/98_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/98_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/98_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/98_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/98_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/98_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/98_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/98_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/98_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/98_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/98_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/98_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/98_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/98_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/98_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/98_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/logic/c_0099.pp
+++ b/manifests/logic/c_0099.pp
@@ -1,25 +1,15 @@
 class clamps::logic::c_0099 {
 
-include clamps::logic::c_0098
+  include clamps::logic::c_0098
 
-file {"/home/${id}/99_of_1": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/99_of_2": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/99_of_3": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/99_of_4": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/99_of_5": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/99_of_6": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/99_of_7": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/99_of_8": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/99_of_9": content => fqdn_rand(999999999999999999999999999999),}
-
-file {"/home/${id}/99_of_10": content => fqdn_rand(999999999999999999999999999999),}
-
+  file {"/home/${id}/99_of_1": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/99_of_2": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/99_of_3": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/99_of_4": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/99_of_5": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/99_of_6": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/99_of_7": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/99_of_8": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/99_of_9": content => "${fqdn_rand(999999999999999999999999999999)}",}
+  file {"/home/${id}/99_of_10": content => "${fqdn_rand(999999999999999999999999999999)}",}
 }

--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -32,7 +32,7 @@ define clamps::mcollective (
 
   file { "/home/$user/.mcollective/ssl/ca.cert.pem":
     content  => file('/etc/puppetlabs/puppet/ssl/certs/ca.pem'),
-  } 
+  }
   file { "/home/$user/.mcollective/ssl/amq.private_key.pem":
     content  => file("/etc/puppetlabs/puppet/ssl/private_keys/${::settings::certname}.pem"),
   }
@@ -56,7 +56,7 @@ define clamps::mcollective (
   service { "pe-mcollective-$user":
     provider  => base,
     ensure    => running,
-    start     => "su $user -c \'/opt/puppet/sbin/mcollectived --pid /home/$user/.mcollective/pe-mcollective.pid --config=/home/$user/.mcollective/server.cfg &\'",
+    start     => "su $user -c \'/opt/puppetlabs/puppet/bin/mcollectived --pid /home/$user/.mcollective/pe-mcollective.pid --config=/home/$user/.mcollective/server.cfg &\'",
     status    => "pgrep -u $user mcollectived",
     stop      => "kill -9 `pgrep -u $user mcollectived`",
     subscribe => File["/home/$user/.mcollective/server.cfg"],

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -17,7 +17,7 @@ define clamps::users (
     managehome => true,
   }
 
-  file { "/home/${user}/.puppet":
+  file { "/home/${user}/.puppetlabs":
     ensure => directory,
     owner  => $user,
   }
@@ -25,7 +25,7 @@ define clamps::users (
   Ini_setting {
     ensure  => 'present',
     section => 'agent',
-    path    => "/home/${user}/.puppet/puppet.conf",
+    path    => "/home/${user}/.puppetlabs/etc/puppet/puppet.conf",
   }
 
   ini_setting { "${user}-certname":
@@ -82,7 +82,7 @@ define clamps::users (
       command => $cron_command,
       user    => $user,
       minute  => [ $cron_1, $cron_2 ],
-      require => File["/home/${user}/.puppet"],
+      require => File["/home/${user}/.puppetlabs"],
     }
   }
 }

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -46,7 +46,7 @@ define clamps::users (
   if $daemonize {
 
     exec { "user ${user} daemon puppet agent":
-      command => "/opt/puppet/bin/puppet agent --daemonize >/dev/null 2>&1",
+      command => "/opt/puppetlabs/puppet/bin/puppet agent --daemonize >/dev/null 2>&1",
       user => $user,
       environment => ["HOME=/home/${user}"],
       path => "/bin:/usr/bin"
@@ -69,12 +69,12 @@ define clamps::users (
     if $metrics_server {
       file { "/home/${user}/time-puppet-run.sh":
         ensure => file,
-        content => "TIMEFORMAT=\"metrics.${::fqdn}.${user}.time %R `date +%s`\"; TIME=$( { time /opt/puppet/bin/puppet agent --onetime --no-daemonize ${splayarg} ${splaylimitarg} > /dev/null; } 2>&1 ); echo \$TIME | nc ${metrics_server} ${metrics_port}",
+        content => "TIMEFORMAT=\"metrics.${::fqdn}.${user}.time %R `date +%s`\"; TIME=$( { time /opt/puppetlabs/puppet/bin/puppet agent --onetime --no-daemonize ${splayarg} ${splaylimitarg} > /dev/null; } 2>&1 ); echo \$TIME | nc ${metrics_server} ${metrics_port}",
       }
     }
 
     $cron_command = $metrics_server ? {
-      undef   => "/opt/puppet/bin/puppet agent --onetime --no-daemonize ${splayarg} ${splaylimitarg}",
+      undef   => "/opt/puppetlabs/puppet/bin/puppet agent --onetime --no-daemonize ${splayarg} ${splaylimitarg}",
       default => "/home/${user}/time-puppet-run.sh",
     }
 

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -17,7 +17,11 @@ define clamps::users (
     managehome => true,
   }
 
-  file { "/home/${user}/.puppetlabs":
+  file { [
+    "/home/${user}/.puppetlabs",
+    "/home/${user}/.puppetlabs/etc",
+    "/home/${user}/.puppetlabs/etc/puppet",
+    ]:
     ensure => directory,
     owner  => $user,
   }

--- a/templates/pe-mcollective.erb
+++ b/templates/pe-mcollective.erb
@@ -18,7 +18,7 @@
 # Description:       Enable service provided by daemon.
 ### END INIT INFO
 
-mcollectived="/opt/puppet/sbin/mcollectived"
+mcollectived="/opt/puppetlabs/puppet/bin/mcollectived"
 pidfile="/home/<%= @user %>/.mcollective/pe-mcollective.pid"
 if [ -d /var/lock/subsys ]; then
     # RedHat/CentOS/etc who use subsys


### PR DESCRIPTION
![](http://www.residentadvisor.net/images/events/flyer/2013/7/nl-0727-495809-185327-front.jpg)

This addresses a number of changes necessary to get clamps running on more recent puppet versions (due to future-parser changes, pathing changes, etc.)

This is a companion to: https://github.com/puppetlabs/pe_acceptance_tests/pull/631

/cc @ericwilliamson @doug-rosser @acidprime 