### PR TITLE
(QENG-2786) mvp to enable turning off non-root mcollective daemons fr…

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -12,6 +12,7 @@ class clamps::agent (
   $shuffle_amq_servers   = true,
   $splay                 = false,
   $splaylimit            = undef,
+  $mco_daemon            = running,
 ) {
 
   file { '/etc/puppetlabs/clamps':

--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -2,6 +2,7 @@ define clamps::mcollective (
   $user       = $title,
   $amqpass    = 'password',
   $amqservers = [$::settings::server],
+  $mco_daemon = $clamps::agent::mco_daemon,
 ) {
 
   # Directories to create / files to copy
@@ -55,7 +56,7 @@ define clamps::mcollective (
 
   service { "pe-mcollective-$user":
     provider  => base,
-    ensure    => running,
+    ensure    => $mco_daemon,
     start     => "su $user -c \'/opt/puppetlabs/puppet/bin/mcollectived --pid /home/$user/.mcollective/pe-mcollective.pid --config=/home/$user/.mcollective/server.cfg &\'",
     status    => "pgrep -u $user mcollectived",
     stop      => "kill -9 `pgrep -u $user mcollectived`",


### PR DESCRIPTION
…om the console

This doesn't allow turning off mcollective daemons from the beaker config file, but I'm not convinced that is 100% required at this point.