### PR TITLE
Fix uneven distribution of cron jobs based on fqdn_rand

### DIFF
--- a/lib/puppet/parser/functions/clamps_user_number.rb
+++ b/lib/puppet/parser/functions/clamps_user_number.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+#usernames are expected to be =~ /^user\d+$/
+#this function is only intended to be used with the clamps_users function
+module Puppet::Parser::Functions
+  newfunction(:clamps_user_number, :type => :rvalue) do |args|
+    username = args.first.to_s
+
+    number = username.sub('user', '')
+  end
+end

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -9,8 +9,10 @@ define clamps::users (
   $splaylimit     = undef,
 ) {
 
-  $cron_1 = fqdn_rand('30',$user)
-  $cron_2 = fqdn_rand('30',$user) + 30
+  $user_cron_minute = clamps_user_number($user) % 30
+
+  $cron_1 = $user_cron_minute
+  $cron_2 = $user_cron_minute + 30
 
   user { $user:
     ensure     => present,


### PR DESCRIPTION
Prior to this commit, the cron jobs created for each user were
based on fqdn_rand which does not gaurentee an even distribution
of agent runs on the clamps node.

After this commit, the cron jobs are created one for in each minute.
so user1 will apply at 1 and 31
user5 will apply at 5, 35
user128 will apply at 8, 38 etc...

If you use a multiple of 30 for your non_rootusers param then you
will get a perfectly event distribution of agent runs.