### PR TITLE
Allow Clamps non-root users to increase file resources each run

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,31 @@
 class clamps (
-  $num_dynamic_files = 5,
-  $num_static_files = 20,
+  $num_dynamic_files     = 5,
+  $num_static_files      = 20,
+  $num_static_files_step = 5,
 ) {
 
   file { [
       "/home/${id}/clamps_files/",
       "/home/${id}/clamps_files/static/",
       "/home/${id}/clamps_files/dynamic/",
+      "/home/${id}/.facter",
+      "/home/${id}/.facter/facts.d"
     ]:
     ensure => directory,
+  }
+
+  $static_files_fact_path = "/home/${id}/.facter/facts.d/static_files.txt"
+
+  exec { 'create static_files fact' :
+    command => "/bin/echo static_files=50 > ${static_files_fact_path}",
+    creates => $static_files_fact_path,
+  }
+
+  $num_static_files_to_make_now = min( pick($::static_files, 0) + $num_static_files_step, $num_static_files)
+
+  file { $static_files_fact_path :
+    ensure  => present,
+    content => "static_files=${num_static_files_to_make_now}",
   }
 
   # create dynamic files
@@ -21,7 +38,7 @@ class clamps (
   }
 
   # create static files
-  $static_files = clamps_files("/home/${id}/clamps_files/static/", $num_static_files)
+  $static_files = clamps_files("/home/${id}/clamps_files/static/", $num_static_files_to_make_now + 0 )
   each($static_files) | $index, $filename | {
     file { $filename:
       ensure  => file,


### PR DESCRIPTION
Prior to this commit, if you wanted 500 files for each non-root user
your only option was to add them all at once.  This puts a large
burden on the masters and even more so on the clamps node trying to
apply all the file changes for lots of non-root users at once.

After this commit, you can control how many files to add each agent
run up to the total number of static files you want to have.  This
allows you to have higher density of non-root agents without manual
intervention to tweak settings after brining up the node the first
time.