### PR TITLE
Allow not managing non-root mcollective settings

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -44,9 +44,11 @@ class clamps::agent (
   # it simply checks for a process named mcollective.
   # The status override in the service resource makes the
   # non-root nodes work though
-  ::clamps::mcollective { $nonroot_usernames:
-    amqservers => $amqserver,
-    amqpass    => $amqpass,
+  if $mco_daemon == 'running' {
+    ::clamps::mcollective { $nonroot_usernames:
+      amqservers => $amqserver,
+      amqpass    => $amqpass,
+    }
   }
 
   # Need to manage the ec2-user if you enabled this


### PR DESCRIPTION
Prior to this commit, we always managed non-root mcollective even
if we did not want to run the service.  Managing the settings
has an issue where they change every run when you point the clamps
agent at a load balancer.

After this commit, we will not manage mcollective for non-root users
when we're not running the mco service for them.  This allows an
easy workaround for pointing the clamps agent at a load balancer.
