### PR TITLE
(PERF-48) Allow setting the orchestration host

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -4,6 +4,7 @@ class clamps::agent (
   $ca                    = $::settings::ca_server,
   $daemonize             = false,
   $master                = $::servername,
+  $server_list           = $::servername,
   $orch_server           = $::servername,
   $metrics_port          = 2003,
   $metrics_server        = undef,
@@ -33,6 +34,7 @@ class clamps::agent (
 
   ::clamps::users { $nonroot_usernames:
     servername     => $master,
+    serverlist     => $server_list,
     ca_server      => $ca,
     metrics_server => $metrics_server,
     metrics_port   => $metrics_port,

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -13,7 +13,9 @@ class clamps::agent (
   $percent_changed_facts = 15,
   $splay                 = false,
   $splaylimit            = undef,
+  $use_cached_catalog = false,
   $mco_daemon            = running,
+  $run_pxp               = false,
 ) {
 
   file { '/etc/puppetlabs/clamps':
@@ -39,8 +41,10 @@ class clamps::agent (
     metrics_server => $metrics_server,
     metrics_port   => $metrics_port,
     daemonize      => $daemonize,
+    run_pxp        => $run_pxp,
     splay          => $splay,
     splaylimit     => $splaylimit,
+    use_cached_catalog => $use_cached_catalog,
   }
 
   # This will not allow the "main" mcollective to start as

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -4,6 +4,7 @@ class clamps::agent (
   $ca                    = $::settings::ca_server,
   $daemonize             = false,
   $master                = $::servername,
+  $orch_server           = $::servername,
   $metrics_port          = 2003,
   $metrics_server        = undef,
   $nonroot_users         = '2',

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -2,6 +2,7 @@ define clamps::users (
   $user           = $title,
   $servername     = $servername,
   $ca_server      = $servername,
+  $serverlist     = $serverlist,
   $metrics_server = undef,
   $metrics_port   = 2003,
   $daemonize      = false,
@@ -55,6 +56,11 @@ define clamps::users (
   ini_setting { "${user}-servername":
     setting => 'server',
     value   => "$servername",
+  }
+
+  ini_setting { "${user}-serverlist":
+    setting => 'server_list',
+    value   => "$serverlist",
   }
 
   ini_setting { "${user}-ca_server":

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -5,7 +5,7 @@ define clamps::users (
   $metrics_server = undef,
   $metrics_port   = 2003,
   $daemonize      = false,
-  $run_pxp        = true,
+  $run_pxp        = false,
   $splay          = false,
   $splaylimit     = undef,
 ) {

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -9,6 +9,7 @@ define clamps::users (
   $run_pxp        = false,
   $splay          = false,
   $splaylimit     = undef,
+  $use_cached_catalog = false,
 ) {
 
   $user_cron_minute = clamps_user_number($user) % 30
@@ -66,6 +67,11 @@ define clamps::users (
   ini_setting { "${user}-ca_server":
     setting => 'ca_server',
     value   => $ca_server,
+  }
+
+  ini_setting { "${user}-use_cached_catalog":
+    setting => 'use_cached_catalog',
+    value   => "${use_cached_catalog}",
   }
 
   file { "${config_path}/etc/pxp-agent/pxp-agent.conf":

--- a/templates/pxp-agent.conf.erb
+++ b/templates/pxp-agent.conf.erb
@@ -1,5 +1,5 @@
 {
-  "broker-ws-uri" : "wss://<%= @servername %>:8142/pcp/",
+  "broker-ws-uri" : "wss://<%= scope['clamps::agent::orch_server'] %>:8142/pcp/",
   "ssl-key" : "<%= @config_path %>/etc/puppet/ssl/private_keys/<%= @agent_certname %>.pem",
   "ssl-ca-cert" : "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
   "ssl-cert" : "<%= @config_path %>/etc/puppet/ssl/certs/<%= @agent_certname %>.pem",


### PR DESCRIPTION
When running with multiple compile masters, the code as-is will attempt to use the loadbalancer as the orchestration host. This does not work. This PR will point the non-root agents to the Master-of-Masters.
