### PR TITLE
(PERF-48) Add the ability to set the Orchestration Host manually

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -4,6 +4,7 @@ class clamps::agent (
   $ca                    = $::settings::ca_server,
   $daemonize             = false,
   $master                = $::servername,
+  $orch_server           = $::servername,
   $metrics_port          = 2003,
   $metrics_server        = undef,
   $nonroot_users         = '2',

--- a/templates/pxp-agent.conf.erb
+++ b/templates/pxp-agent.conf.erb
@@ -1,5 +1,5 @@
 {
-  "broker-ws-uri" : "wss://<%= @servername %>:8142/pcp/",
+  "broker-ws-uri" : "wss://<%= scope['clamps::agent::orch_server'] %>:8142/pcp/",
   "ssl-key" : "<%= @config_path %>/etc/puppet/ssl/private_keys/<%= @agent_certname %>.pem",
   "ssl-ca-cert" : "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
   "ssl-cert" : "<%= @config_path %>/etc/puppet/ssl/certs/<%= @agent_certname %>.pem",


### PR DESCRIPTION
When you have Compile Masters and a Load Balancer, the code will try to have the pxp-agents connect to the Load Balancer.