### PR TITLE
Turn non-root agent mco daemons off by default

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -12,7 +12,7 @@ class clamps::agent (
   $percent_changed_facts = 15,
   $splay                 = false,
   $splaylimit            = undef,
-  $mco_daemon            = running,
+  $mco_daemon            = stopped,
 ) {
 
   file { '/etc/puppetlabs/clamps':


### PR DESCRIPTION
We have not been testing with mco and they use a significant amount of memory on the agent hosts.

NOTE - I haven't tested this yet. It's a simple change, I know...