### PR TITLE
(maint) Use default ping-interval

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -15,7 +15,7 @@ class clamps::agent (
   $splay                 = false,
   $splaylimit            = undef,
   $mco_daemon            = running,
-  $pxp_ping_interval     = 15,
+  $pxp_ping_interval     = undef,
 ) {
 
   file { '/etc/puppetlabs/clamps':

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -85,7 +85,6 @@ define clamps::users (
   }
 
   $pcp_v2_compatible = versioncmp($::puppetversion, '4.9.0') >= 0
-  $pcp_version_config = if $pcp_v2_compatible { '"pcp-version": "2",' } else { '' }
   $pcp_endpoint = if $pcp_v2_compatible { 'pcp2' } else { 'pcp' }
 
   file { "${config_path}/etc/pxp-agent/pxp-agent.conf":

--- a/templates/pxp-agent.conf.erb
+++ b/templates/pxp-agent.conf.erb
@@ -6,7 +6,11 @@
   "pidfile" : "<%= @config_path %>/var/run/pxp-agent.pid",
   "logfile" : "<%= @config_path %>/var/log/pxp-agent.log",
   "loglevel" : "debug",
-  <%= @pcp_version_config %>
+<% if @pcp_v2_compatible -%>
+  "pcp-version": "2",
+<% end -%>
+<% if scope['clamps::agent::pxp_ping_interval'] -%>
   "ping-interval" : <%= scope['clamps::agent::pxp_ping_interval'] %>,
+<% end -%>
   "spool-dir" : "<%= @config_path %>/opt/pxp-agent/spool"
 }


### PR DESCRIPTION
Avoid overriding ping-interval to 15 seconds. pxp-agent 1.5 uses a
longer default.