### PR TITLE
(ORCH-1652) Add docs, allow configuring a sleep for mock puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,22 @@ This class accepts the following parameters:
  - `$amqserver` (`String`): Server name for MCollective AMQP connection.
  - `$ca` (`String`): Name of CA server.
  - `$daemonize` (`Boolean`): Run non-root agents daemonized? (default: `false`)
+ - '$environment' ('String'): Required by mock pxp-module-puppet to run in an environment. (default: `production`)
  - `$master` (`String`): Name of puppet master server.
+ - `$orch_server` (`String`: Name of server to use with agents for Orchestration.
  - `$metrics_port` (`Integer`): Port to use when connecting to graphite server.
  - `$metrics_server` (`String`): Name of server where graphite is running.
  - `$nonroot_users` (`Integer`): Number of non-root user agents to create. (default: 2)
  - `$num_facts_per_agent` (`Integer`): Number of facts to create per non-root user agent.
  - `$percent_changed_facts` (`Integer`): What percentage (0-100) of facts will have new values on each run?
+ - `$use_cached_catalog` ('Boolean'): Agents use cached catalogs, i.e. avoid node request, submitting facts and compiling catalog. (default: `false`)
+ - `$run_interval` (`Integer`): Interval for agent runs via cron. (default: `30`)
  - `$splay` (`Boolean`):  Enable `--splay` for non-user agent runs? (default: `false`).  See [Configuration: splay](https://docs.puppetlabs.com/references/latest/configuration.html#splay) for puppet agent semantics.
  - `$splaylimit` (`String`): Set the `--splaylimit` parameter for non-user agent runs? (default: unset). Implies `splay`.  See [Configuration: splaylimit](https://docs.puppetlabs.com/references/latest/configuration.html#splaylimit) for puppet agent semantics.
+ - `$mco_daemon` (`String`): If undefined, mcollective is not managed. Otherwise should be `running` or `stopped` to enforce state of mcollective daemon. (default: unset)
+ - `$pxp_ping_interval` (`Integer`): Ping interval for pxp-agent. (default: unset)
+ - `$pxp_mock_puppet` (`Boolean`, `Number`): If truthy, use a mock puppet agent for cron runs and pxp-agent. If a number, uses that as a sleep period before sending the report to simulate agent activity. Negated when `$daemonize` is `true`. (default: `false`)
+ - `$crond` (`String`): Manage the crond service. (default: `running`)
 
 #### `clamps`
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -22,7 +22,7 @@ class clamps::agent (
 ) {
 
   # Disable filebucket backups while managing clamps agents.
-  # This has no affect on the agent runs themselves.
+  # This has no effect on the agent runs themselves.
   File {
     backup => false
   }

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -11,6 +11,7 @@ define clamps::users (
   $run_interval   = $clamps::agent::run_interval,
   $splay          = false,
   $splaylimit     = undef,
+  $pxp_mock_puppet = $clamps::agent::pxp_mock_puppet,
   $facts_cache    = undef,
 ) {
 
@@ -97,7 +98,7 @@ define clamps::users (
     require => File["${config_path}/etc/pxp-agent/"],
   }
 
-  if $clamps::agent::pxp_mock_puppet {
+  if $pxp_mock_puppet {
     file { "${config_path}/opt/pxp-agent/modules/pxp-module-puppet":
       ensure  => file,
       owner   => $user,
@@ -150,7 +151,7 @@ define clamps::users (
 
   } else {
 
-    if $clamps::agent::pxp_mock_puppet {
+    if $pxp_mock_puppet {
       $puppet_run = "echo '{\"use_cached_catalog\": ${use_cached_catalog}}' | ${config_path}/opt/pxp-agent/modules/pxp-module-puppet run"
     } else {
       if $splaylimit {

--- a/templates/pxp-agent.conf.erb
+++ b/templates/pxp-agent.conf.erb
@@ -12,7 +12,7 @@
 <% if scope['clamps::agent::pxp_ping_interval'] -%>
   "ping-interval" : <%= scope['clamps::agent::pxp_ping_interval'] %>,
 <% end -%>
-<% if scope['clamps::agent::pxp_mock_puppet'] -%>
+<% if @pxp_mock_puppet -%>
   "modules-dir": "<%= @config_path %>/opt/pxp-agent/modules",
 <% end -%>
   "spool-dir" : "<%= @config_path %>/opt/pxp-agent/spool"

--- a/templates/pxp-module-puppet.erb
+++ b/templates/pxp-module-puppet.erb
@@ -480,6 +480,10 @@ def run(use_cached_catalog)
     File.write(cache_path, catalog_resp.body)
   end
 
+<% if @pxp_mock_puppet.is_a?(Numeric) -%>
+  sleep <%= @pxp_mock_puppet %>
+
+<% end -%>
   # PUT /puppet/v3/report/<cert>?environment=<env> body=report
   report = generate_report(cert, catalog['version'], tx_uuid, catalog['catalog_uuid'], catalog['code_id'], env)
   report_resp = session.put("/puppet/v3/report/#{cert}?environment=#{env}", report.to_json, 'Content-Type' => 'text/pson')

--- a/tests/pxp-module-puppet.rb
+++ b/tests/pxp-module-puppet.rb
@@ -8,7 +8,8 @@ require 'fileutils'
 @user = 'user1'
 @agent_certname = "#{@user}-#{@facts['fqdn']}"
 @config_path = File.join(ENV['HOME'], '.puppetlabs')
+@pxp_mock_puppet = true
 
 FileUtils::mkdir_p("#{@config_path}/opt/pxp-agent/modules")
-temp = ERB.new(File.read('templates/pxp-module-puppet.erb'))
+temp = ERB.new(File.read('templates/pxp-module-puppet.erb'), nil, '-')
 File.write("#{@config_path}/opt/pxp-agent/modules/pxp-module-puppet", temp.result)


### PR DESCRIPTION
Document recent changes, and allow specifying a sleep period for the
mock puppet agent to simulate agent run time.