### PR TITLE
(QA-3231) classification broken in Hoyt for pxp-agent

### DIFF
--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -62,6 +62,7 @@ define clamps::users (
     "${config_path}/opt/pxp-agent",
     "${config_path}/opt/pxp-agent/modules",
     "${config_path}/opt/pxp-agent/spool",
+    "${config_path}/opt/pxp-agent/tasks-cache",
     ]:
     ensure => directory,
     owner  => $user,

--- a/templates/pxp-agent.conf.erb
+++ b/templates/pxp-agent.conf.erb
@@ -16,5 +16,5 @@
   "modules-dir": "<%= @config_path %>/opt/pxp-agent/modules",
 <% end -%>
   "spool-dir" : "<%= @config_path %>/opt/pxp-agent/spool",
-  "tasks-cache-dir" : "<%= @config_path %>/opt/pxp-agent/tasks-cache"
+  "task-cache-dir" : "<%= @config_path %>/opt/pxp-agent/tasks-cache"
 }

--- a/templates/pxp-agent.conf.erb
+++ b/templates/pxp-agent.conf.erb
@@ -16,5 +16,5 @@
   "modules-dir": "<%= @config_path %>/opt/pxp-agent/modules",
 <% end -%>
   "spool-dir" : "<%= @config_path %>/opt/pxp-agent/spool",
-  "cache-dir" : "<%= @config_path %>/opt/pxp-agent/tasks-cache"
+  "tasks-cache-dir" : "<%= @config_path %>/opt/pxp-agent/tasks-cache"
 }

--- a/templates/pxp-agent.conf.erb
+++ b/templates/pxp-agent.conf.erb
@@ -15,5 +15,6 @@
 <% if @pxp_mock_puppet -%>
   "modules-dir": "<%= @config_path %>/opt/pxp-agent/modules",
 <% end -%>
-  "spool-dir" : "<%= @config_path %>/opt/pxp-agent/spool"
+  "spool-dir" : "<%= @config_path %>/opt/pxp-agent/spool",
+  "cache-dir" : "<%= @config_path %>/opt/pxp-agent/tasks-cache"
 }


### PR DESCRIPTION
Non-root users cannot (and SHOULD NOT) use the default of '/opt/puppetlabs/pxp-agent/tasks-cache' as the tasks cache directory.