### PR TITLE
(maint) Remove duplicate resource declaration

### DIFF
--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -63,7 +63,6 @@ define clamps::users (
     "${config_path}/opt/pxp-agent/modules",
     "${config_path}/opt/pxp-agent/tasks-cache",
     "${config_path}/opt/pxp-agent/spool",
-    "${config_path}/opt/pxp-agent/tasks-cache",
     ]:
     ensure => directory,
     owner  => $user,


### PR DESCRIPTION
We try to make a file twice! We only need it once :)