### PR TITLE
(maint) Remove default file amqpass value

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,5 +1,5 @@
 class clamps::agent (
-  $amqpass               = file('/etc/puppetlabs/mcollective/credentials'),
+  $amqpass               = undef,
   $amqserver             = [$::servername],
   $ca                    = $::settings::ca_server,
   $daemonize             = false,


### PR DESCRIPTION
This commit removes the default mcollective file value for the
`amqpass` agent parameter.  Since mcollective no longer ships with
PE, this file resource is not present on newer installations and
the default lookup will fail.  The parameter is left in place and
can be set to the appropriate value when used on a system that
supports mcollective.